### PR TITLE
Attempt to fix GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,5 @@ jobs:
           ecmwf/ecbuild
           ecmwf/eckit
           ecmwf/eccodes
+          MathisRosenhauer/libaec@master
         dependency_branch: develop


### PR DESCRIPTION
ecCodes CI uses libaec@master to build so we probably should too.