### PR TITLE
Fix reusable CI inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
   # Trigger the workflow on pull request
   pull_request: ~
 
+  # Trigger the workflow manually
+  workflow_dispatch: ~
+
 jobs:
   # Run CI including downstream packages on self-hosted runners
   downstream-ci:

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -6,31 +6,28 @@ on:
       metkit:
         required: false
         type: string
-        default: 'ecmwf/metkit@develop'
       eccodes:
         required: false
         type: string
-        default: 'ecmwf/eccodes@develop'
       eckit:
         required: false
         type: string
-        default: 'ecmwf/eckit@develop'
 
 jobs:
   ci:
     name: metkit-ci
     uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v2
     with:
-      repository: ${{ inputs.metkit }}
+      repository: ${{ inputs.metkit || 'ecmwf/metkit@develop' }}
       name_prefix: metkit-
       build_package_inputs: |
-        repository: ${{ inputs.metkit }}
+        repository: ${{ inputs.metkit || 'ecmwf/metkit@develop' }}
         self_coverage: true
         dependencies: |
           ecmwf/ecbuild
           MathisRosenhauer/libaec@master
-          ${{ inputs.eccodes }}
-          ${{ inputs.eckit }}
+          ${{ inputs.eccodes || 'ecmwf/eccodes' }}
+          ${{ inputs.eckit || 'ecmwf/eckit' }}
         dependency_branch: develop
         parallelism_factor: 8
     secrets: inherit

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -6,12 +6,15 @@ on:
       metkit:
         required: false
         type: string
+        default: 'ecmwf/metkit@develop'
       eccodes:
         required: false
         type: string
+        default: 'ecmwf/eccodes@develop'
       eckit:
         required: false
         type: string
+        default: 'ecmwf/eckit@develop'
 
 jobs:
   ci:
@@ -26,8 +29,8 @@ jobs:
         dependencies: |
           ecmwf/ecbuild
           MathisRosenhauer/libaec@master
-          ${{ inputs.eccodes || 'ecmwf/eccodes' }}
-          ${{ inputs.eckit || 'ecmwf/eckit' }}
+          ${{ inputs.eccodes }}
+          ${{ inputs.eckit }}
         dependency_branch: develop
         parallelism_factor: 8
     secrets: inherit


### PR DESCRIPTION
Adds default values to `reusable-ci.yml` inputs. When called as part of downstream CI of another package, some inputs might be null.