### PR TITLE
Run CI for public PRs after approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,15 @@ on:
   # Trigger the workflow manually
   workflow_dispatch: ~
 
+  # Trigger after public PR approved for CI
+  pull_request_target:
+    types: [labeled]
+
 jobs:
   # Run CI including downstream packages on self-hosted runners
   downstream-ci:
     name: downstream-ci
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
       metkit: ecmwf/metkit@${{ github.event.pull_request.head.sha || github.sha }}
@@ -28,7 +33,7 @@ jobs:
   private-downstream-ci:
     name: private-downstream-ci
     needs: [downstream-ci]
-    if: success() || failure()
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -45,6 +50,7 @@ jobs:
   # Build downstream packages on HPC
   downstream-ci-hpc:
     name: downstream-ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       metkit: ecmwf/metkit@${{ github.event.pull_request.head.sha || github.sha }}
@@ -54,7 +60,7 @@ jobs:
   private-downstream-ci-hpc:
     name: private-downstream-ci-hpc
     needs: [downstream-ci-hpc]
-    if: success() || failure()
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,10 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2


### PR DESCRIPTION
CI for pull requests originating from forks will run only when labeled with `approved-for-ci` label. Label `contributor` will be added to such PRs. Label `approved-for-ci` will be removed whenever contents of the PR change.

CI for pull requests from internal branches will run the same way as before.