### PR TITLE
Add missing inline keyword to function replaceTable()

### DIFF
--- a/src/metkit/mars/ParamID.h
+++ b/src/metkit/mars/ParamID.h
@@ -66,7 +66,7 @@ public: // methods
 
 //----------------------------------------------------------------------------------------------------------------------
 
-long replaceTable(size_t table, long paramid) {
+inline long replaceTable(size_t table, long paramid) {
     return (table*1000 + paramid%1000);
 }
 


### PR DESCRIPTION
Adding inline is necessary to avoid duplicate symbols.