### PR TITLE
Remove Debian 11 from CI matrix

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -18,6 +18,8 @@ jobs:
     name: metkit-ci
     uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v2
     with:
+      skip_matrix_jobs: |
+        gnu@debian-11
       repository: ${{ inputs.metkit || 'ecmwf/metkit@develop' }}
       name_prefix: metkit-
       build_package_inputs: |


### PR DESCRIPTION
Tests are failing, so skip this platform to unblock other CI work. The platform should be re-enabled once the tests are fixed.