### PR TITLE
Remove Ubuntu 22.04 from build matrix

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       skip_matrix_jobs: |
         gnu@debian-11
+        gnu@ubuntu-22.04
       repository: ${{ inputs.metkit || 'ecmwf/metkit@develop' }}
       name_prefix: metkit-
       build_package_inputs: |


### PR DESCRIPTION
The tests are failing the same way as on Debian (#13). Temporarily disable Ubuntu 22.04 build until #13 fixed.