### PR TITLE
Compile with C++17 as eckit also is C++17 now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package( ecbuild 3.7.2 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_C
 
 project( metkit LANGUAGES CXX )
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ########################################################################################################################


### PR DESCRIPTION
In multio we compile eckit, metkit and fdb together.

We are getting a lot of warnings because eckit already uses C++17 features.