### PR TITLE
Add clear defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ### dependencies and options
 
 if(NOT METKIT_CONFIGS_BRANCH)
-    set(METKIT_CONFIGS_BRANCH chk)
+    set(METKIT_CONFIGS_BRANCH enum)
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/share")

--- a/src/metkit/mars/MarsLanguage.cc
+++ b/src/metkit/mars/MarsLanguage.cc
@@ -94,8 +94,8 @@ MarsLanguage::MarsLanguage(const std::string& verb) : verb_(verb) {
     }
 
     if (lang.contains("_clear_defaults")) {
-        auto keywords = lang["_clear_defaults"];
-        for (size_t i = 0; i < keywords.size(); ++i) {
+        const auto& keywords = lang["_clear_defaults"];
+        for (auto i = 0; i < keywords.size(); ++i) {
             if (auto iter = types_.find(keywords[i]); iter != types_.end()) { iter->second->clearDefaults(); }
         }
     }

--- a/src/metkit/mars/MarsLanguage.cc
+++ b/src/metkit/mars/MarsLanguage.cc
@@ -93,6 +93,13 @@ MarsLanguage::MarsLanguage(const std::string& verb) : verb_(verb) {
         }
     }
 
+    if (lang.contains("_clear_defaults")) {
+        auto keywords = lang["_clear_defaults"];
+        for (size_t i = 0; i < keywords.size(); ++i) {
+            if (auto iter = types_.find(keywords[i]); iter != types_.end()) { iter->second->clearDefaults(); }
+        }
+    }
+
     std::set<std::string> keywordsInAxis;
     for (const std::string& a : hypercube::AxisOrder::instance().axes()) {
         keywordsInAxis.insert(a);
@@ -101,12 +108,10 @@ MarsLanguage::MarsLanguage(const std::string& verb) : verb_(verb) {
         if(it != types_.end()) {
             t = (*it).second;
         }
-        typesByAxisOrder_.push_back(std::make_pair(a,t)); 
+        typesByAxisOrder_.emplace_back(a, t);
     }
     for (const auto& [k,t] : types_) {
-        if (keywordsInAxis.find(k) == keywordsInAxis.end()) {
-            typesByAxisOrder_.push_back(std::make_pair(k,t));
-        }
+        if (keywordsInAxis.find(k) == keywordsInAxis.end()) { typesByAxisOrder_.emplace_back(k, t); }
     }
 }
 
@@ -220,9 +225,7 @@ std::string MarsLanguage::bestMatch(const MarsExpandContext& ctx, const std::str
 
     static std::string empty;
     if (best.empty()) {
-        if (!fail) {        
-            return empty;
-        }
+        if (!fail) { return empty; }
 
         std::ostringstream oss;
         oss << "Cannot match [" << name << "] in " << values << ctx;
@@ -250,7 +253,7 @@ std::string MarsLanguage::bestMatch(const MarsExpandContext& ctx, const std::str
     if (!fail) {
         return empty;
     }
-    
+
     std::ostringstream oss;
     oss << "Ambiguous value '" << name << "' could be";
 

--- a/tests/test_expand.cc
+++ b/tests/test_expand.cc
@@ -644,7 +644,7 @@ CASE( "test_metkit_expand_d1" ) {
                 {"param", {"134","137"}}
             };
         expand(text, "retrieve", expected, {20000101});
-    }   
+    }
     {
         const char* text = "retrieve,date=20120515,time=0000,dataset=climate-dt,activity=cmip6,experiment=hist,generation=1,model=icon,realization=1,resolution=high,class=d1,expver=0001,type=fc,stream=clte,levelist=1,levtype=o3d,param=263500";
         std::map<std::string, std::vector<std::string>> expected{
@@ -665,7 +665,7 @@ CASE( "test_metkit_expand_d1" ) {
                 {"param", {"263500"}}
             };
         expand(text, "retrieve", expected, {20120515});
-    }           
+    }
 }
 CASE( "test_metkit_expand_ng" ) {
     {
@@ -689,6 +689,58 @@ CASE( "test_metkit_expand_ng" ) {
             };
         expand(text, "retrieve", expected, {20000101});
     }
+}
+
+CASE("test_metkit_expand_list") {
+  {
+    const char *text = "list,date=20250105,domain=g,levtype=pl,expver="
+                       "0001,step=0,stream=oper,levelist=1000/850/700/500/400/"
+                       "300,time=1200,type=an,param=129";
+    std::map<std::string, std::vector<std::string>> expected{
+        {"class", {"od"}},
+        {"date", {"20250105"}},
+        {"domain", {"g"}},
+        {"levtype", {"pl"}},
+        {"levelist", {"1000", "850", "700", "500", "400", "300"}},
+        {"expver", {"0001"}},
+        {"time", {"1200"}},
+        {"stream", {"oper"}},
+        {"type", {"an"}},
+        {"param", {"129"}}};
+    expand(text, "list", expected, {20250105});
+  }
+  {
+    const char *text = "list,class=tr,date=20250105";
+    std::map<std::string, std::vector<std::string>> expected{
+        {"class", {"tr"}}, {"date", {"20250105"}}};
+    expand(text, "list", expected, {20250105});
+  }
+}
+
+CASE("test_metkit_expand_read") {
+  {
+    const char *text = "read,class=tr,date=20250105,domain=g,levtype=pl,expver="
+                       "0001,step=0,stream=oper,levelist=1000/850/700/500/400/"
+                       "300,time=1200,type=an,param=129";
+    std::map<std::string, std::vector<std::string>> expected{
+        {"class", {"tr"}},
+        {"date", {"20250105"}},
+        {"domain", {"g"}},
+        {"levtype", {"pl"}},
+        {"levelist", {"1000", "850", "700", "500", "400", "300"}},
+        {"expver", {"0001"}},
+        {"time", {"1200"}},
+        {"stream", {"oper"}},
+        {"type", {"an"}},
+        {"param", {"129"}}};
+    expand(text, "read", expected, {20250105});
+  }
+  {
+    const char *text = "read,date=20250105,param=129";
+    std::map<std::string, std::vector<std::string>> expected{
+        {"date", {"20250105"}}, {"param", {"129"}}};
+    expand(text, "read", expected, {20250105});
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
restores old behavior where defaults were dropped for certain types and verbs
used for verbs: list, read, pointdb