### PR TITLE
Minor: Modified metkit build tools variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,9 @@ if(NOT METKIT_CONFIGS_BRANCH)
     set(METKIT_CONFIGS_BRANCH chk)
 endif()
 
-ecbuild_add_option( FEATURE BUILD_TOOLS
+ecbuild_add_option( FEATURE METKIT_BUILD_TOOLS
                     DEFAULT ON
-                    DESCRIPTION "Build the command line tools" )
+                    DESCRIPTION "Build the metkit command line tools" )
 
 ecbuild_add_option( FEATURE EXPERIMENTAL
                     DEFAULT OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ ecbuild_add_option( FEATURE METKIT_BUILD_TOOLS
                     DEFAULT ON
                     DESCRIPTION "Build the metkit command line tools" )
 
+# If build tools are off, also disable the metkit build tools
+if(NOT BUILD_TOOLS)
+    set(METKIT_BUILD_TOOLS OFF)
+endif()
+
 ecbuild_add_option( FEATURE EXPERIMENTAL
                     DEFAULT OFF
                     DESCRIPTION "Experimental features" )

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -37,7 +37,7 @@
 # )
 
 ecbuild_add_executable( TARGET    parse-mars-request
-    CONDITION HAVE_GRIB AND HAVE_BUILD_TOOLS
+    CONDITION HAVE_GRIB AND HAVE_METKIT_BUILD_TOOLS
     SOURCES   parse-mars-request.cc
     INCLUDES  ${ECKIT_INCLUDE_DIRS}
     LIBS        metkit eckit_option eckit eccodes
@@ -46,14 +46,14 @@ ecbuild_add_executable( TARGET    parse-mars-request
 
 ecbuild_add_executable( TARGET    odb-to-request
     SOURCES   odb-to-request.cc
-    CONDITION HAVE_ODB AND HAVE_BUILD_TOOLS
+    CONDITION HAVE_ODB AND HAVE_METKIT_BUILD_TOOLS
     INCLUDES  ${ECKIT_INCLUDE_DIRS}
     NO_AS_NEEDED
     LIBS      metkit eckit_option )
 
 ecbuild_add_executable( TARGET    bufr-sanity-check
     SOURCES   bufr-sanity-check.cc
-    CONDITION HAVE_BUFR AND HAVE_BUILD_TOOLS
+    CONDITION HAVE_BUFR AND HAVE_METKIT_BUILD_TOOLS
     INCLUDES  ${ECKIT_INCLUDE_DIRS}
     NO_AS_NEEDED
     LIBS      metkit eckit_option )
@@ -61,7 +61,7 @@ ecbuild_add_executable( TARGET    bufr-sanity-check
 ecbuild_add_executable(
     TARGET        mars-archive-script
     SOURCES       mars-archive-script.cc
-    CONDITION     HAVE_BUILD_TOOLS
+    CONDITION     HAVE_METKIT_BUILD_TOOLS
     INCLUDES      ${ECKIT_INCLUDE_DIRS}
     NO_AS_NEEDED
     LIBS          metkit

--- a/tests/marsgen/CMakeLists.txt
+++ b/tests/marsgen/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach( _test ${marsgen_tests} )
 
     ecbuild_add_test(
         TYPE       SCRIPT
-        CONDITION  HAVE_BUILD_TOOLS
+        CONDITION  HAVE_METKIT_BUILD_TOOLS
         COMMAND    metkit_marsgen_${_test}.sh )
 
 endforeach()

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (HAVE_BUILD_TOOLS) # test scripts use the metkit tools
+if (HAVE_METKIT_BUILD_TOOLS) # test scripts use the metkit tools
     add_subdirectory(METK-89)
     add_subdirectory(METK-103)
 endif()

--- a/tests/regressions/METK-103/CMakeLists.txt
+++ b/tests/regressions/METK-103/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if (HAVE_BUFR AND HAVE_BUILD_TOOLS)
+if (HAVE_BUFR AND HAVE_METKIT_BUILD_TOOLS )
     ecbuild_configure_file( METK-103.sh.in METK-103.sh @ONLY )
 
     ecbuild_add_test(

--- a/tests/regressions/METK-89/CMakeLists.txt
+++ b/tests/regressions/METK-89/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if ( HAVE_GRIB AND HAVE_BUILD_TOOLS )
+if ( HAVE_GRIB AND HAVE_METKIT_BUILD_TOOLS)
     ecbuild_configure_file( METK-89.sh.in METK-89.sh @ONLY )
 
     ecbuild_add_test(


### PR DESCRIPTION
Issue was that the metkit build tools were relying on the BUILD_TOOLS CMake variable which was doubly used in many different projects. I introduced a new ecbuild option called METKIT_BUILD_TOOLS which can be set in the corresponding bundle.yaml with ENABLE_METKIT_BUILD_TOOLS=OFF. Per default this is set to ON.