### PR TITLE
Fix/metk 126 strict

### DIFF
--- a/share/metkit/language.yaml
+++ b/share/metkit/language.yaml
@@ -1436,8 +1436,8 @@ retrieve:
     flatten: false
     type: enum
     values:
-    - none
-    - auto
+    - [none, n, 0]
+    - [auto, automatic]
 
 ##############################################################
 

--- a/src/metkit/mars/Type.cc
+++ b/src/metkit/mars/Type.cc
@@ -385,12 +385,12 @@ void Type::setDefaults(MarsRequest& request) {
         for (const auto& unsetContext : unsets_) {
             if (unsetContext->matches(request)) {
                 unset=true;
+                break;
             }
         }
         if (!unset) {
             for (const auto& [defaultContext, values] : defaults_) {
-                if (defaultContext->matches(request)) {
-                    
+                if (defaultContext->matches(request)) {                    
                     request.setValuesTyped(this, values);
                     break;
                 }

--- a/tests/test_expand.cc
+++ b/tests/test_expand.cc
@@ -37,6 +37,7 @@ using ExpectedOutput=std::map<std::string, std::vector<std::string>>;
 
 //-----------------------------------------------------------------------------
 
+
 void expand(const MarsRequest& r, const std::string& verb, const ExpectedOutput& expected, const std::vector<long> dates) {
     // MarsExpension exp(false);
     // MarsRequest r=exp.expand(req);
@@ -44,11 +45,14 @@ void expand(const MarsRequest& r, const std::string& verb, const ExpectedOutput&
     ASSERT(r.verb() ==verb);
     for(const auto& [key, vals] : expected) {
         if (!r.has(key)) {
-                std::cerr << "Expected key " << key << " not found!" << std::endl;
+            std::cerr << "Expected key " << key << " not found!" << std::endl;
         }
         ASSERT(r.has(key));
         auto vv=r.values(key);
-        ASSERT(vv.size() ==vals.size());
+        if (key != "date" && vv.size() != vals.size()) { // dates are verified at a later stage
+            std::cerr << "Expecting " << vals.size() << " values for key " << key << " - found " << vv.size() << " values" << std::endl;
+            ASSERT(vv.size() ==vals.size());
+        }
         for (int i=0; i<vv.size(); i++) {
             if (vv.at(i) != vals.at(i)) {
                 std::cerr << "Error comparing " << key << " -- expecting: " << vals.at(i) << " found: " << vv.at(i) << std::endl;
@@ -59,25 +63,30 @@ void expand(const MarsRequest& r, const std::string& verb, const ExpectedOutput&
     if (dates.size() > 0) {
         ASSERT(r.has("date"));
         auto dd=r.values("date");
-        ASSERT(dd.size() ==dates.size());
+        if (dd.size() != dates.size()) {
+            std::cerr << "expecting: " << dates << " found: " << dd << std::endl;
+        }
+        ASSERT(dd.size() == dates.size());
         for (int i=0; i<dates.size(); i++) {
             long d=dates.at(i);
             if (d<0) {
                 eckit::Date day(d);
                 d=day.yyyymmdd();
             }
-            ASSERT(dd.at(i) ==std::to_string(d));
+            if (dd.at(i) != std::to_string(d)) {
+                std::cerr << "Error comparing dates. Expecting: " << std::to_string(d) << " found: " << dd.at(i) << std::endl;
+            }
+            ASSERT(dd.at(i) == std::to_string(d));
         }
     }
 }
 
-
-void expand(const std::string& text, const std::string& verb, const ExpectedOutput& expected, std::vector<long> dates) {
-    MarsRequest r=MarsRequest::parse(text, true);
+void expand(const std::string& text, const std::string& verb, const ExpectedOutput& expected, std::vector<long> dates, bool strict = false) {
+    MarsRequest r=MarsRequest::parse(text, strict);
     expand(r, verb, expected, std::move(dates));
 }
 
-void expand(const std::string& text, const std::string& verb, const std::string& expected, std::vector<long> dates) {
+void expand(const std::string& text, const std::string& verb, const std::string& expected, bool strict = false, std::vector<long> dates = {}) {
     ExpectedOutput out;
     eckit::Tokenizer c(",");
     eckit::Tokenizer e("=");
@@ -90,6 +99,9 @@ void expand(const std::string& text, const std::string& verb, const std::string&
         e(tt, kv);
         ASSERT(kv.size() == 2);
         auto key = eckit::StringTools::lower(eckit::StringTools::trim(kv[0]));
+        if (key == "date") {
+            ASSERT(dates.size() == 0);
+        }
         eckit::StringList vals;
         s(kv[1], vals);
         std::vector<std::string> vv;
@@ -98,16 +110,23 @@ void expand(const std::string& text, const std::string& verb, const std::string&
             if (key != "source" && key != "target") {
                 val = eckit::StringTools::lower(val);
             }
-            vv.push_back(val);
+            if (key == "date") {
+                dates.push_back(std::stol(val));
+            }
+            else {
+                vv.push_back(val);
+            }
         }
-        out.emplace(key, vv);
+        if (key != "date") {
+            out.emplace(key, vv);
+        }
     }
-    MarsRequest r=MarsRequest::parse(text, true);
-    // expand(r, verb, out, std::move(dates));
+    MarsRequest r=MarsRequest::parse(text, strict);
+    expand(r, verb, out, std::move(dates));
 }
 
-void expandException(const std::string& text) {
-    EXPECT_THROWS(MarsRequest::parse(text, true));
+void expandException(const std::string& text, bool strict = false) {
+    EXPECT_THROWS(MarsRequest::parse(text, strict));
 }
 
 CASE( "test_metkit_expand_1" ) {
@@ -126,8 +145,12 @@ CASE( "test_metkit_expand_1" ) {
         };
     expand(text, "retrieve", expected, {-5,-4,-3,-2,-1});
 
-    const char* expectedStr = "CLASS      = OD,    TYPE       = AN,    STREAM     = OPER,    EXPVER     = 0001,    REPRES     = SH,    LEVTYPE    = PL,    LEVELIST   = 1000/850/700/500/400/300,    PARAM      = 129,    TIME       = 1200,    STEP       = 00,    DOMAIN     = G";
-    expand(text, "retrieve", expectedStr, {-5,-4,-3,-2,-1});
+    const char* text2 = "ret,date=-5/to/-1.";
+    expand(text2, "retrieve", expected, {-5,-4,-3,-2,-1});
+
+    // const char* expectedStr = "CLASS = OD,TYPE = AN,STREAM = OPER,EXPVER = 0001,REPRES = SH,LEVTYPE = PL,LEVELIST = 1000/850/700/500/400/300,PARAM = 129,TIME = 1200,STEP = 00,DOMAIN = G";
+    const char* expectedStr = "CLASS = OD,TYPE = AN,STREAM = OPER,EXPVER = 0001,LEVTYPE = PL,LEVELIST = 1000/850/700/500/400/300,PARAM = 129,TIME = 1200,STEP = 0,DOMAIN = G";
+    expand(text, "retrieve", expectedStr, true, {-5,-4,-3,-2,-1});
 }
 
 CASE( "test_metkit_expand_2" ) {
@@ -295,6 +318,22 @@ CASE( "test_metkit_expand_9_strict" ) {
 
         ASSERT(v.size() ==1);
         v[0].dump(std::cout);
+    }
+    {
+        const char* text = "retrieve,class=od,expver=1,date=20240304,time=0,type=fc,levtype=sfc,levelist=1/2/3,step=0,param=2t,target=out";
+        expandException(text, true);
+        // const char* expected = "CLASS=OD,TYPE=FC,STREAM=OPER,EXPVER=0001,REPRES=GG,LEVTYPE=SFC,PARAM=167,DATE=20240304,TIME=0000,STEP=0,DOMAIN=G,TARGET=out";
+        // TODO REPRES
+        const char* expected = "CLASS=OD,TYPE=FC,STREAM=OPER,EXPVER=0001,LEVTYPE=SFC,PARAM=167,DATE=20240304,TIME=0000,STEP=0,DOMAIN=G,TARGET=out";
+        expand(text, "retrieve", expected, false);
+    }
+    {
+        const char* text = "retrieve,class=od,expver=1,stream=enfo,date=20240304,time=0,type=cf,levtype=sfc,levelist=1/2/3,step=0,param=2t,number=1/2/3,target=out";
+        expandException(text, true);
+        // const char* expected = "CLASS=OD,TYPE=CF,STREAM=ENFO,EXPVER=0001,REPRES=SH,LEVTYPE=SFC,PARAM=167,DATE=20240304,TIME=0000,STEP=0,DOMAIN=G,TARGET=out";
+        // TODO REPRES
+        const char* expected = "CLASS=OD,TYPE=CF,STREAM=ENFO,EXPVER=0001,LEVTYPE=SFC,PARAM=167,DATE=20240304,TIME=0000,STEP=0,DOMAIN=G,TARGET=out";
+        expand(text, "retrieve", expected, false);
     }
 }
 
@@ -834,13 +873,13 @@ CASE("test_metkit_expand_clmn") {
 CASE("test_metkit_expand_") {
     {
         const char* text = "retrieve,accuracy=16,area=60.0/-60.0/-60.0/60.0,class=ea,date=20101029,expver=1,grid=0.30/0.30,levelist=1/to/137,levtype=ml,number=-1,param=q/t/u/v/lnsp/z,rotation=0.0/0.0,step=000,stream=oper,time=15:00:00,type=an,target=\"reference.1OEDK0.data\"";
-        const char* expected = "CLASS=EA,TYPE=AN,STREAM=OPER, EXPVER=0001, LEVTYPE=ML, LEVELIST=1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/25/26/27/28/29/30/31/32/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/50/51/52/53/54/55/56/57/58/59/60/61/62/63/64/65/66/67/68/69/70/71/72/73/74/75/76/77/78/79/80/81/82/83/84/85/86/87/88/89/90/91/92/93/94/95/96/97/98/99/100/101/102/103/104/105/106/107/108/109/110/111/112/113/114/115/116/117/118/119/120/121/122/123/124/125/126/127/128/129/130/131/132/133/134/135/136/137, PARAM=133/130/131/132/152/129, TIME=1500, STEP=000, DOMAIN=G, TARGET=reference.1OEDK0.data, RESOL=AUTO, ACCURACY=16, AREA=60/-60/-60/60, ROTATION=0.0/0.0, GRID=.3/.3";
-        expand(text, "retrieve", expected, {20101029});
+        const char* expected = "CLASS=EA,TYPE=AN,STREAM=OPER, EXPVER=0001, LEVTYPE=ML, LEVELIST=1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/25/26/27/28/29/30/31/32/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/50/51/52/53/54/55/56/57/58/59/60/61/62/63/64/65/66/67/68/69/70/71/72/73/74/75/76/77/78/79/80/81/82/83/84/85/86/87/88/89/90/91/92/93/94/95/96/97/98/99/100/101/102/103/104/105/106/107/108/109/110/111/112/113/114/115/116/117/118/119/120/121/122/123/124/125/126/127/128/129/130/131/132/133/134/135/136/137, PARAM=133/130/131/132/152/129, TIME=1500, STEP=000, DOMAIN=G, TARGET=reference.1OEDK0.data, RESOL=AUTO, ACCURACY=16, AREA=60/-60/-60/60, ROTATION=0.0/0.0, GRID=.3/.3,DATE=20101029";
+        // expand(text, "retrieve", expected);
     }
     {
         const char* text = "retrieve,accuracy=10,class=ea,date=1969-03-28,expver=11,grid=0.25/0.25,levtype=sfc,packing=si,param=142.128/143.128/151.128/165.128/166.128,step=0/6/12/18/24/30/36/42/48/54/60/66/72/78/84/90/96/102/108/114/120/132/144/156/168/180/192/204/216/228/240,stream=oper,time=00:00:00,type=fc,target=\"reference.rFP7XB.data\"";
         const char* expected = "CLASS      = EA,    TYPE       = FC,    STREAM     = OPER,    EXPVER     = 0011,     LEVTYPE    = SFC,    PARAM      = 142.128/143.128/151.128/165.128/166.128,    TIME       = 0000,    STEP       = 0/6/12/18/24/30/36/42/48/54/60/66/72/78/84/90/96/102/108/114/120/132/144/156/168/180/192/204/216/228/240,    DOMAIN     = G,    TARGET     = reference.rFP7XB.data,    RESOL      = AUTO,    ACCURACY   = 10,    GRID       = 0.25/0.25,    PACKING    = SIMPLE";
-        expand(text, "retrieve", expected, {19690328});
+        // expand(text, "retrieve", expected, {19690328});
     }
     
 }

--- a/tests/test_expand.cc
+++ b/tests/test_expand.cc
@@ -42,31 +42,31 @@ void expand(const MarsRequest& r, const std::string& verb, const ExpectedOutput&
     // MarsExpension exp(false);
     // MarsRequest r=exp.expand(req);
     std::cout << "comparing " << r << " with " << expected << " dates " << dates << std::endl;
-    ASSERT(r.verb() ==verb);
+    EXPECT_EQUAL(r.verb(), verb);
     for(const auto& [key, vals] : expected) {
         if (!r.has(key)) {
             std::cerr << "Expected key " << key << " not found!" << std::endl;
         }
-        ASSERT(r.has(key));
+        EXPECT(r.has(key));
         auto vv=r.values(key);
         if (key != "date" && vv.size() != vals.size()) { // dates are verified at a later stage
             std::cerr << "Expecting " << vals.size() << " values for key " << key << " - found " << vv.size() << " values" << std::endl;
-            ASSERT(vv.size() ==vals.size());
+            EXPECT_EQUAL(vv.size(), vals.size());
         }
         for (int i=0; i<vv.size(); i++) {
             if (vv.at(i) != vals.at(i)) {
                 std::cerr << "Error comparing " << key << " -- expecting: " << vals.at(i) << " found: " << vv.at(i) << std::endl;
             }
-            ASSERT(vv.at(i) ==vals.at(i));
+            EXPECT_EQUAL(vv.at(i), vals.at(i));
         }
     }
     if (dates.size() > 0) {
-        ASSERT(r.has("date"));
+        EXPECT(r.has("date"));
         auto dd=r.values("date");
         if (dd.size() != dates.size()) {
             std::cerr << "expecting: " << dates << " found: " << dd << std::endl;
         }
-        ASSERT(dd.size() == dates.size());
+        EXPECT_EQUAL(dd.size(), dates.size());
         for (int i=0; i<dates.size(); i++) {
             long d=dates.at(i);
             if (d<0) {
@@ -76,7 +76,7 @@ void expand(const MarsRequest& r, const std::string& verb, const ExpectedOutput&
             if (dd.at(i) != std::to_string(d)) {
                 std::cerr << "Error comparing dates. Expecting: " << std::to_string(d) << " found: " << dd.at(i) << std::endl;
             }
-            ASSERT(dd.at(i) == std::to_string(d));
+            EXPECT_EQUAL(dd.at(i), std::to_string(d));
         }
     }
 }
@@ -97,10 +97,10 @@ void expand(const std::string& text, const std::string& verb, const std::string&
         auto tt = eckit::StringTools::trim(t);
         eckit::StringList kv;
         e(tt, kv);
-        ASSERT(kv.size() == 2);
+        EXPECT_EQUAL(kv.size(), 2);
         auto key = eckit::StringTools::lower(eckit::StringTools::trim(kv[0]));
         if (key == "date") {
-            ASSERT(dates.size() == 0);
+            EXPECT_EQUAL(dates.size(), 0);
         }
         eckit::StringList vals;
         s(kv[1], vals);
@@ -307,7 +307,7 @@ CASE( "test_metkit_expand_9_strict" ) {
         MarsExpension expand(false, false);
         std::vector<MarsRequest> v=expand.expand(parser.parse());
 
-        ASSERT(v.size() ==1);
+        EXPECT_EQUAL(v.size(), 1);
         v[0].dump(std::cout);
     }
     {
@@ -316,7 +316,7 @@ CASE( "test_metkit_expand_9_strict" ) {
         MarsExpension expand(false, true);
         std::vector<MarsRequest> v=expand.expand(parser.parse());
 
-        ASSERT(v.size() ==1);
+        EXPECT_EQUAL(v.size(), 1);
         v[0].dump(std::cout);
     }
     {
@@ -345,7 +345,7 @@ CASE( "test_metkit_expand_10_strict" ) {
         MarsExpension expand(false, false);
         std::vector<MarsRequest> v=expand.expand(parser.parse());
 
-        ASSERT(v.size() ==1);
+        EXPECT_EQUAL(v.size(), 1);
         v[0].dump(std::cout);
     }
 }
@@ -385,7 +385,7 @@ void expandKey(const std::string& key, std::vector<std::string> values, std::vec
     std::cout << key << " " << values;
     t->expand(ctx, values);
     std::cout << " ==> " << values << " - expected " << expected << std::endl;
-    ASSERT(values ==expected);
+    EXPECT_EQUAL(values, expected);
 }
 
 void quantileThrows(std::vector<std::string> values) {
@@ -871,14 +871,23 @@ CASE("test_metkit_expand_clmn") {
 }
 
 CASE("test_metkit_expand_") {
+    // issues from https://confluence.ecmwf.int/pages/viewpage.action?pageId=496866851
+    // not yet supported (thus the tests are disabled)
     {
-        const char* text = "retrieve,accuracy=16,area=60.0/-60.0/-60.0/60.0,class=ea,date=20101029,expver=1,grid=0.30/0.30,levelist=1/to/137,levtype=ml,number=-1,param=q/t/u/v/lnsp/z,rotation=0.0/0.0,step=000,stream=oper,time=15:00:00,type=an,target=\"reference.1OEDK0.data\"";
-        const char* expected = "CLASS=EA,TYPE=AN,STREAM=OPER, EXPVER=0001, LEVTYPE=ML, LEVELIST=1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/25/26/27/28/29/30/31/32/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/50/51/52/53/54/55/56/57/58/59/60/61/62/63/64/65/66/67/68/69/70/71/72/73/74/75/76/77/78/79/80/81/82/83/84/85/86/87/88/89/90/91/92/93/94/95/96/97/98/99/100/101/102/103/104/105/106/107/108/109/110/111/112/113/114/115/116/117/118/119/120/121/122/123/124/125/126/127/128/129/130/131/132/133/134/135/136/137, PARAM=133/130/131/132/152/129, TIME=1500, STEP=000, DOMAIN=G, TARGET=reference.1OEDK0.data, RESOL=AUTO, ACCURACY=16, AREA=60/-60/-60/60, ROTATION=0.0/0.0, GRID=.3/.3,DATE=20101029";
+        // https://jira.ecmwf.int/browse/MARS-962
+        const char* text = "retrieve,accuracy=12,area=90.0/0.0/-90.0/359.5,date=20240102,domain=g,grid=0.5/0.5,leve=off,levtype=sfc,padding=0,param=134/137/165/166/167/168/235,stream=da,style=dissemination,time=00,type=an,target=\"reference.tzpUX7.data\"";
+        const char* expected = "CLASS=OD,TYPE=AN,STREAM=OPER,EXPVER=0001,REPRES=GG,LEVTYPE=SFC,PARAM=134/137/165/166/167/168/235,DATE=20240102,TIME=0000,STEP=00,DOMAIN=G,TARGET=\"reference.tzpUX7.data\",RESOL=AV,ACCURACY=12,STYLE=DISSEMINATION,AREA=90.0/0.0/-90.0/359.5,GRID=0.5/0.5,PADDING=0";
         // expand(text, "retrieve", expected);
     }
     {
+        const char* text = "retrieve,accuracy=16,area=60.0/-60.0/-60.0/60.0,class=ea,date=20101029,expver=1,grid=0.30/0.30,levelist=1/to/137,levtype=ml,number=-1,param=q/t/u/v/lnsp/z,rotation=0.0/0.0,step=000,stream=oper,time=15:00:00,type=an,target=\"reference.1OEDK0.data\"";
+        const char* expected = "CLASS=EA,TYPE=AN,STREAM=OPER,EXPVER=0001,LEVTYPE=ML,LEVELIST=1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/25/26/27/28/29/30/31/32/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/50/51/52/53/54/55/56/57/58/59/60/61/62/63/64/65/66/67/68/69/70/71/72/73/74/75/76/77/78/79/80/81/82/83/84/85/86/87/88/89/90/91/92/93/94/95/96/97/98/99/100/101/102/103/104/105/106/107/108/109/110/111/112/113/114/115/116/117/118/119/120/121/122/123/124/125/126/127/128/129/130/131/132/133/134/135/136/137,PARAM=133/130/131/132/152/129,TIME=1500,STEP=000,DOMAIN=G,TARGET=reference.1OEDK0.data,RESOL=AUTO,ACCURACY=16,AREA=60/-60/-60/60,ROTATION=0.0/0.0,GRID=.3/.3,DATE=20101029";
+        // expand(text, "retrieve", expected);
+    }
+    {
+        // https://jira.ecmwf.int/browse/MARS-959
         const char* text = "retrieve,accuracy=10,class=ea,date=1969-03-28,expver=11,grid=0.25/0.25,levtype=sfc,packing=si,param=142.128/143.128/151.128/165.128/166.128,step=0/6/12/18/24/30/36/42/48/54/60/66/72/78/84/90/96/102/108/114/120/132/144/156/168/180/192/204/216/228/240,stream=oper,time=00:00:00,type=fc,target=\"reference.rFP7XB.data\"";
-        const char* expected = "CLASS      = EA,    TYPE       = FC,    STREAM     = OPER,    EXPVER     = 0011,     LEVTYPE    = SFC,    PARAM      = 142.128/143.128/151.128/165.128/166.128,    TIME       = 0000,    STEP       = 0/6/12/18/24/30/36/42/48/54/60/66/72/78/84/90/96/102/108/114/120/132/144/156/168/180/192/204/216/228/240,    DOMAIN     = G,    TARGET     = reference.rFP7XB.data,    RESOL      = AUTO,    ACCURACY   = 10,    GRID       = 0.25/0.25,    PACKING    = SIMPLE";
+        const char* expected = "CLASS=EA,TYPE=FC,STREAM=OPER,EXPVER=0011,LEVTYPE=SFC,PARAM=142.128/143.128/151.128/165.128/166.128,TIME=0000,STEP=0/6/12/18/24/30/36/42/48/54/60/66/72/78/84/90/96/102/108/114/120/132/144/156/168/180/192/204/216/228/240,DOMAIN=G,TARGET=reference.rFP7XB.data,RESOL=AUTO,ACCURACY=10,GRID=0.25/0.25,PACKING=SIMPLE";
         // expand(text, "retrieve", expected, {19690328});
     }
     

--- a/tests/test_expand.cc
+++ b/tests/test_expand.cc
@@ -42,41 +42,28 @@ void expand(const MarsRequest& r, const std::string& verb, const ExpectedOutput&
     // MarsExpension exp(false);
     // MarsRequest r=exp.expand(req);
     std::cout << "comparing " << r << " with " << expected << " dates " << dates << std::endl;
-    EXPECT_EQUAL(r.verb(), verb);
-    for(const auto& [key, vals] : expected) {
-        if (!r.has(key)) {
-            std::cerr << "Expected key " << key << " not found!" << std::endl;
-        }
-        EXPECT(r.has(key));
-        auto vv=r.values(key);
-        if (key != "date" && vv.size() != vals.size()) { // dates are verified at a later stage
-            std::cerr << "Expecting " << vals.size() << " values for key " << key << " - found " << vv.size() << " values" << std::endl;
-            EXPECT_EQUAL(vv.size(), vals.size());
+    EXPECT_EQUAL(verb, r.verb());
+    for(const auto& e : expected) {
+        EXPECT(r.has(e.first));
+        auto vv=r.values(e.first);
+        if (e.first != "date") { // dates are verified at a later stage
+            EXPECT_EQUAL(e.second.size(), vv.size());
         }
         for (int i=0; i<vv.size(); i++) {
-            if (vv.at(i) != vals.at(i)) {
-                std::cerr << "Error comparing " << key << " -- expecting: " << vals.at(i) << " found: " << vv.at(i) << std::endl;
-            }
-            EXPECT_EQUAL(vv.at(i), vals.at(i));
+            EXPECT_EQUAL(e.second.at(i), vv.at(i));
         }
     }
     if (dates.size() > 0) {
         EXPECT(r.has("date"));
         auto dd=r.values("date");
-        if (dd.size() != dates.size()) {
-            std::cerr << "expecting: " << dates << " found: " << dd << std::endl;
-        }
-        EXPECT_EQUAL(dd.size(), dates.size());
+        EXPECT_EQUAL(dates.size(), dd.size());
         for (int i=0; i<dates.size(); i++) {
             long d=dates.at(i);
             if (d<0) {
                 eckit::Date day(d);
                 d=day.yyyymmdd();
             }
-            if (dd.at(i) != std::to_string(d)) {
-                std::cerr << "Error comparing dates. Expecting: " << std::to_string(d) << " found: " << dd.at(i) << std::endl;
-            }
-            EXPECT_EQUAL(dd.at(i), std::to_string(d));
+            EXPECT_EQUAL(std::to_string(d), dd.at(i));
         }
     }
 }
@@ -97,10 +84,10 @@ void expand(const std::string& text, const std::string& verb, const std::string&
         auto tt = eckit::StringTools::trim(t);
         eckit::StringList kv;
         e(tt, kv);
-        EXPECT_EQUAL(kv.size(), 2);
+        EXPECT_EQUAL(2, kv.size());
         auto key = eckit::StringTools::lower(eckit::StringTools::trim(kv[0]));
         if (key == "date") {
-            EXPECT_EQUAL(dates.size(), 0);
+            EXPECT_EQUAL(0, dates.size());
         }
         eckit::StringList vals;
         s(kv[1], vals);


### PR DESCRIPTION
re-enabled strict mars request expansion
(set/unset are used for validation and not for request massaging)