### PR TITLE
Python wheel: add publish of the pymetkit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,11 @@ jobs:
   deploy:
     uses: ecmwf/reusable-workflows/.github/workflows/create-package.yml@v2
     secrets: inherit
-  wheel:
+  wheel-wrapper:
     uses: ./.github/workflows/build-wheel-wrapper.yml
     secrets: inherit
+  wheel-python:
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    secrets: inherit
+    needs:
+      - wheel-wrapper


### PR DESCRIPTION
Adds publishing of the `pymetkit` wheel, triggered by git tag push, after the `metkitlib` wheel is built and published

The same pattern as currently done in multio (and I presume we'll do it like that everywhere)

It is currently unsolved how to propagate the pin dynamically -- that is, we currently have `pymetkit` with a dependency on `metkitlib`, but we want to have `metkitlib>=VERSION, < VERSION (maj incr)` instead. I'll deal with that later.

Lastly, once we move the `pyproject.toml` to `python/pymetkit` where it belongs, we'll need to update this `cd.yml` action with a path param