### PR TITLE
METK-132 : Fix bug converting sparse hypercubes to dense mars requests

### DIFF
--- a/src/metkit/hypercube/HyperCube.cc
+++ b/src/metkit/hypercube/HyperCube.cc
@@ -169,7 +169,7 @@ requestRelation getRelation(const metkit::mars::MarsRequest& base, const size_t&
     tmp.merge(additional);  // creates the bounding box request
 
     /// @todo: building a hypercube *JUST* to get the size? Seems like we can do better
-    size_t sizeAfter = HyperCube(tmp).size();
+    size_t sizeAfter = tmp.count();
 
     if (sizeAfter == baseSize)
         return requestRelation::EMBEDDED;
@@ -187,7 +187,7 @@ bool mergeLast(std::vector<std::pair<metkit::mars::MarsRequest, size_t>>& reques
     size_t candidateIdx  = std::numeric_limits<size_t>::max();
     size_t candidateSize = 0;
 
-    // check id the new request is embedded or adjacent to existing requests
+    // check if the new request is embedded or adjacent to existing requests
     for (size_t j = 0; j < requests.size() - 1; j++) {
         requestRelation relation =
             getRelation(requests[j].first, requests[j].second, requests[last].first, requests[last].second);

--- a/src/metkit/hypercube/HyperCube.h
+++ b/src/metkit/hypercube/HyperCube.h
@@ -72,7 +72,7 @@ protected:
     int indexOf(const metkit::mars::MarsRequest&) const;
     bool clear(int index);
     metkit::mars::MarsRequest requestOf(size_t index) const;
-    std::vector<std::pair<metkit::mars::MarsRequest, size_t>> request(std::set<size_t> idxs) const;
+    std::vector<std::pair<metkit::mars::MarsRequest, size_t>> request(const std::set<size_t>& idxs) const;
 
 private:
 

--- a/src/metkit/hypercube/HyperCube.h
+++ b/src/metkit/hypercube/HyperCube.h
@@ -72,6 +72,10 @@ protected:
     int indexOf(const metkit::mars::MarsRequest&) const;
     bool clear(int index);
     metkit::mars::MarsRequest requestOf(size_t index) const;
+
+    // Given a set of indices, build the *minimal* collection of Mars requests that cover them.
+    // Each entry in the result vector is: { merged_request, number_of_points_covered_by_that_request }
+    /// @note: This does not take into account whether the point is "set" or not
     std::vector<std::pair<metkit::mars::MarsRequest, size_t>> request(const std::set<size_t>& idxs) const;
 
 private:

--- a/tests/test_hypercube.cc
+++ b/tests/test_hypercube.cc
@@ -142,12 +142,10 @@ CASE("test_metkit_hypercube_request") {
     EXPECT(!(*cube.vacantRequests().begin() < r155));
 }
 
-//-----------------------------------------------------------------------------
 CASE("test_metkit_hypercube_request METK-132") {
     std::vector<std::string> keys = {"levelist", "param"};
-    
-    // MarsRequest r = MarsRequest::parse("retrieve,levelist=1/2/3/4/5,param=228038/235077/235078/235094");
-    MarsRequest r = MarsRequest::parse("retrieve,levelist=1/5/3,param=228038/235094/235077/235078");
+
+    MarsRequest r = MarsRequest::parse("retrieve,levelist=2/4/1/3/5,param=228038/235094/235077/235078");
     metkit::hypercube::HyperCube cube{r};
 
     // unset levelist 5 for params 235077/235094
@@ -155,30 +153,29 @@ CASE("test_metkit_hypercube_request METK-132") {
     cube.clear(MarsRequest::parse("retrieve,levelist=5,param=235094"));
 
     std::vector<MarsRequest> expected_flat_requests = {
-        MarsRequest::parse("retrieve,levelist=1,param=228038"),
-        MarsRequest::parse("retrieve,levelist=3,param=228038"),
-        MarsRequest::parse("retrieve,levelist=5,param=228038"),
-        MarsRequest::parse("retrieve,levelist=1,param=235077"),
-        MarsRequest::parse("retrieve,levelist=3,param=235077"),
-        MarsRequest::parse("retrieve,levelist=1,param=235094"),
-        MarsRequest::parse("retrieve,levelist=3,param=235094"),
-        MarsRequest::parse("retrieve,levelist=1,param=235078"),
-        MarsRequest::parse("retrieve,levelist=3,param=235078"),
-        MarsRequest::parse("retrieve,levelist=5,param=235078"),
-
+        MarsRequest::parse("retrieve,levelist=1,param=228038"), MarsRequest::parse("retrieve,levelist=2,param=228038"),
+        MarsRequest::parse("retrieve,levelist=3,param=228038"), MarsRequest::parse("retrieve,levelist=4,param=228038"),
+        MarsRequest::parse("retrieve,levelist=5,param=228038"), MarsRequest::parse("retrieve,levelist=1,param=235077"),
+        MarsRequest::parse("retrieve,levelist=2,param=235077"), MarsRequest::parse("retrieve,levelist=3,param=235077"),
+        MarsRequest::parse("retrieve,levelist=4,param=235077"), MarsRequest::parse("retrieve,levelist=1,param=235094"),
+        MarsRequest::parse("retrieve,levelist=2,param=235094"), MarsRequest::parse("retrieve,levelist=3,param=235094"),
+        MarsRequest::parse("retrieve,levelist=4,param=235094"), MarsRequest::parse("retrieve,levelist=1,param=235078"),
+        MarsRequest::parse("retrieve,levelist=2,param=235078"), MarsRequest::parse("retrieve,levelist=3,param=235078"),
+        MarsRequest::parse("retrieve,levelist=4,param=235078"), MarsRequest::parse("retrieve,levelist=5,param=235078"),
         // These two requests we have removed from the cube:
         // MarsRequest::parse("retrieve,levelist=5,param=235077"),
         // MarsRequest::parse("retrieve,levelist=5,param=235094"),
     };
-    
+
     std::vector<MarsRequest> flattened_requests;
-    for (const auto& req : cube.vacantRequests()) { // surely this should be requests, not vacantRequests... anyway...
+    for (const auto& req : cube.vacantRequests()) {  // surely this should be requests, not vacantRequests... anyway...
         auto flattened = req.split(keys);
         for (const auto& f : flattened) {
             flattened_requests.push_back(f);
         }
     }
 
+    EXPECT_EQUAL(flattened_requests.size(), 18);
     EXPECT_EQUAL(flattened_requests.size(), expected_flat_requests.size());
 
     // compare both vectors

--- a/tests/test_hypercube.cc
+++ b/tests/test_hypercube.cc
@@ -167,6 +167,9 @@ CASE("test_metkit_hypercube_request METK-132") {
         // MarsRequest::parse("retrieve,levelist=5,param=235094"),
     };
 
+    auto dense_requests = cube.vacantRequests();
+    EXPECT_EQUAL(dense_requests.size(), 2);
+
     std::vector<MarsRequest> flattened_requests;
     for (const auto& req : cube.vacantRequests()) {  // surely this should be requests, not vacantRequests... anyway...
         auto flattened = req.split(keys);

--- a/tests/test_hypercube.cc
+++ b/tests/test_hypercube.cc
@@ -143,6 +143,52 @@ CASE("test_metkit_hypercube_request") {
 }
 
 //-----------------------------------------------------------------------------
+CASE("test_metkit_hypercube_request METK-132") {
+    std::vector<std::string> keys = {"levelist", "param"};
+    
+    // MarsRequest r = MarsRequest::parse("retrieve,levelist=1/2/3/4/5,param=228038/235077/235078/235094");
+    MarsRequest r = MarsRequest::parse("retrieve,levelist=1/5/3,param=228038/235094/235077/235078");
+    metkit::hypercube::HyperCube cube{r};
+
+    // unset levelist 5 for params 235077/235094
+    cube.clear(MarsRequest::parse("retrieve,levelist=5,param=235077"));
+    cube.clear(MarsRequest::parse("retrieve,levelist=5,param=235094"));
+
+    std::vector<MarsRequest> expected_flat_requests = {
+        MarsRequest::parse("retrieve,levelist=1,param=228038"),
+        MarsRequest::parse("retrieve,levelist=3,param=228038"),
+        MarsRequest::parse("retrieve,levelist=5,param=228038"),
+        MarsRequest::parse("retrieve,levelist=1,param=235077"),
+        MarsRequest::parse("retrieve,levelist=3,param=235077"),
+        MarsRequest::parse("retrieve,levelist=1,param=235094"),
+        MarsRequest::parse("retrieve,levelist=3,param=235094"),
+        MarsRequest::parse("retrieve,levelist=1,param=235078"),
+        MarsRequest::parse("retrieve,levelist=3,param=235078"),
+        MarsRequest::parse("retrieve,levelist=5,param=235078"),
+
+        // These two requests we have removed from the cube:
+        // MarsRequest::parse("retrieve,levelist=5,param=235077"),
+        // MarsRequest::parse("retrieve,levelist=5,param=235094"),
+    };
+    
+    std::vector<MarsRequest> flattened_requests;
+    for (const auto& req : cube.vacantRequests()) { // surely this should be requests, not vacantRequests... anyway...
+        auto flattened = req.split(keys);
+        for (const auto& f : flattened) {
+            flattened_requests.push_back(f);
+        }
+    }
+
+    EXPECT_EQUAL(flattened_requests.size(), expected_flat_requests.size());
+
+    // compare both vectors
+    std::sort(flattened_requests.begin(), flattened_requests.end());
+    std::sort(expected_flat_requests.begin(), expected_flat_requests.end());
+    for (size_t i = 0; i < expected_flat_requests.size(); ++i) {
+        EXPECT_EQUAL(flattened_requests[i].values("levelist"), expected_flat_requests[i].values("levelist"));
+        EXPECT_EQUAL(flattened_requests[i].values("param"), expected_flat_requests[i].values("param"));
+    }
+}
 
 }  // namespace metkit::mars::test
 


### PR DESCRIPTION
The bug turned out to be in the mergeLater function. Upon finding an adjacent request it would sometimes merge into a non-adjacent request.

Also refactor the Hypercubes::requests() function for clarity.

Additional refactoring of this class is likely to appear in a followup request, as there are a few confusing aspects.
 