### PR TITLE
Minor: Fix typo

### DIFF
--- a/src/metkit/mars/Type.cc
+++ b/src/metkit/mars/Type.cc
@@ -412,7 +412,7 @@ void Type::expand(const MarsExpandContext& ctx, std::vector<std::string>& values
     std::swap(newvals, values);
 
     if (!multiple_ && values.size() > 1) {
-        throw eckit::UserError("Only one value passible for '" + name_ + "'");
+        throw eckit::UserError("Only one value possible for '" + name_ + "'");
     }
 }
 


### PR DESCRIPTION
There was a typo in a eckit::UserError error message if more than one type was entered for the MARS key type.