### PR TITLE
Python wrapper wheel: fix dependencies

### DIFF
--- a/python/metkitlib/buildconfig
+++ b/python/metkitlib/buildconfig
@@ -13,4 +13,5 @@
 NAME="metkit"
 CMAKE_PARAMS="-Deckit_ROOT=/tmp/metkit/prereqs/eckitlib -Deccodes_ROOT=/tmp/metkit/prereqs/eccodeslib -DENABLE_GRIB=1"
 PYPROJECT_DIR="python/metkitlib"
-DEPENDENCIES='["eckitlib", "eccodeslib"]'
+# NOTE fckitlib is explicitly included just as a workaround for dependency resolver
+DEPENDENCIES='["eckitlib", "fckitlib", "eccodeslib"]'


### PR DESCRIPTION
There is a deficiency to dependency resolution when building python wrapper wheels -- I temporarily get around that here by explicitly listing fckit. Nothing changes in the sense that fckit has been brought in as a dependency anyway via eccodes