### PR TITLE
Remove eccodes library

### DIFF
--- a/src/metkit/CMakeLists.txt
+++ b/src/metkit/CMakeLists.txt
@@ -97,7 +97,7 @@ list( APPEND metkit_srcs
     hypercube/HyperCube.cc
     hypercube/HyperCube.h
     hypercube/HyperCubePayloaded.h
-    api/metkit_c.cc 
+    api/metkit_c.cc
     api/metkit_c.h
 )
 
@@ -133,8 +133,6 @@ if ( HAVE_GRIB )
         codes/BUFRDecoder.h
         codes/GRIBDecoder.cc
         codes/GRIBDecoder.h
-        codes/LibEccodes.cc
-        codes/LibEccodes.h
         codes/CodesContent.cc
         codes/CodesContent.h
         codes/BufrContent.cc
@@ -154,7 +152,14 @@ if ( HAVE_GRIB )
         codes/GribIterator.cc
         codes/GribIterator.h
         codes/CodesHandleDeleter.h
+    )
+
+    if( NOT eccodes_HAVE_GEOGRAPHY OR NOT eccodes_HAVE_ECKIT_GEO )
+        list( APPEND metkit_srcs
+            codes/LibEccodes.cc
+            codes/LibEccodes.h
         )
+    endif()
 
     set( grib_libs eccodes )
 


### PR DESCRIPTION
The Cmake conditional include of (metkit's) LibEccodes.h/cc is the complimetary to build eccodes with eckit::geo.

In my opinion this code should be completely removed from Metkit (I mean, not just conditionally). To myunderstanding this is only for reporting the eccodes version to some of the tools that require eccodes, but this is not in the right place.

This is teh cause of building the stack (in github or metabuilder) when two libraries named "eccodes" are present. It's currently making those builds fail.