### PR TITLE
Feature: Float array extraction

### DIFF
--- a/src/metkit/codes/CodesContent.cc
+++ b/src/metkit/codes/CodesContent.cc
@@ -166,7 +166,6 @@ void CodesContent::getFloatArray(const std::string& key, float* data, size_t len
 }
 
 
-
 //----------------------------------------------------------------------------------------------------------------------
 
 eckit::message::MessageContent* CodesContent::transform(const eckit::StringDict& dict) const {

--- a/src/metkit/codes/CodesContent.cc
+++ b/src/metkit/codes/CodesContent.cc
@@ -127,6 +127,18 @@ void CodesContent::getDoubleArray(const std::string& key, std::vector<double>& v
     ASSERT(count == size);
 }
 
+//----------------------------------------------------------------------------------------------------------------------
+
+void CodesContent::getFloatArray(const std::string& key, std::vector<float>& values) const {
+    size_t size = 0;
+    CODES_CALL(codes_get_size(handle_, key.c_str(), &size));
+
+    size_t count = size;
+    values.resize(count);
+    CODES_CALL(codes_get_float_array(handle_, key.c_str(), &values[0], &count));
+    ASSERT(count == size);
+}
+
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -144,6 +156,15 @@ void CodesContent::getDoubleArray(const std::string& key, double* data, size_t l
     CODES_CALL(codes_get_double_array(handle_, key.c_str(), data, &count));
     ASSERT(count == len);
 }
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void CodesContent::getFloatArray(const std::string& key, float* data, size_t len) const {
+    size_t count = len;
+    CODES_CALL(codes_get_float_array(handle_, key.c_str(), data, &count));
+    ASSERT(count == len);
+}
+
 
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/codes/CodesContent.h
+++ b/src/metkit/codes/CodesContent.h
@@ -49,8 +49,10 @@ private:
     long getLong(const std::string& key) const override;
     double getDouble(const std::string& key) const override;
     void getDoubleArray(const std::string& key, std::vector<double>& values) const override;
+    void getFloatArray(const std::string& key, std::vector<float>& values) const override;
     size_t getSize(const std::string& key) const override;
     void getDoubleArray(const std::string& key, double* data, size_t lenExpected) const override;
+    void getFloatArray(const std::string& key, float* data, size_t lenExpected) const override;
 
     eckit::Offset offset() const override;
     const codes_handle* codesHandle() const;


### PR DESCRIPTION
### Description
This PR introduces the ability to extract `CodesContent` as a `FloatAarray`. This can be merged, once the corresponding `eckit` PR is merged: https://github.com/ecmwf/eckit/pull/211.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 