### PR TITLE
[WIP]: Remove DummyContext

### DIFF
--- a/src/metkit/mars/MarsExpansion.cc
+++ b/src/metkit/mars/MarsExpansion.cc
@@ -38,8 +38,8 @@ void MarsExpansion::reset() {
 }
 
 
-MarsLanguage& MarsExpansion::language(const MarsExpandContext& ctx, const std::string& verb) {
-    auto v = MarsLanguage::expandVerb(ctx, verb);
+MarsLanguage& MarsExpansion::language(const std::string& verb) {
+    auto v = MarsLanguage::expandVerb(verb);
 
     if (auto j = languages_.find(v); j != languages_.end()) {
         return *(*j).second;
@@ -54,34 +54,29 @@ std::vector<MarsRequest> MarsExpansion::expand(const std::vector<MarsParsedReque
     std::vector<MarsRequest> result;
     result.reserve(requests.size());
 
-    DummyContext cc;
-    MarsExpandContext& ctx = cc;
-
     // Implement inheritence
     for (const auto& request : requests) {
-        auto& lang = language(ctx, request.verb());
-        result.emplace_back(lang.expand(ctx, request, inherit_, strict_));
-        ctx = request;
+        auto& lang = language( request.verb());
+        result.emplace_back(lang.expand(request, inherit_, strict_));
     }
 
     return result;
 }
 
 MarsRequest MarsExpansion::expand(const MarsRequest& request) {
-    DummyContext ctx;
-    auto& lang = language(ctx, request.verb());
-    return lang.expand(ctx, request, inherit_, strict_);
+    auto& lang = language(request.verb());
+    return lang.expand(request, inherit_, strict_);
 }
 
 
-void MarsExpansion::expand(const MarsExpandContext& ctx, const MarsRequest& request, ExpandCallback& callback) {
-    MarsRequest r = language(ctx, request.verb()).expand(ctx, request, inherit_, strict_);
-    callback(ctx, r);
+void MarsExpansion::expand(const MarsRequest& request, ExpandCallback& callback) {
+    MarsRequest r = language(request.verb()).expand(request, inherit_, strict_);
+    callback(r);
 }
 
 
-void MarsExpansion::flatten(const MarsExpandContext& ctx, const MarsRequest& request, FlattenCallback& callback) {
-    language(ctx, request.verb()).flatten(ctx, request, callback);
+void MarsExpansion::flatten(const MarsRequest& request, FlattenCallback& callback) {
+    language(request.verb()).flatten(request, callback);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/MarsExpansion.h
+++ b/src/metkit/mars/MarsExpansion.h
@@ -45,7 +45,7 @@ class ExpandCallback {
 public:
 
     virtual ~ExpandCallback();
-    virtual void operator()(const MarsExpandContext&, const MarsRequest&) = 0;
+    virtual void operator()(const MarsRequest&) = 0;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -61,12 +61,12 @@ public:
     MarsRequest expand(const MarsRequest&);
     std::vector<MarsRequest> expand(const std::vector<MarsParsedRequest>&);
 
-    void expand(const MarsExpandContext&, const MarsRequest&, ExpandCallback&);
-    void flatten(const MarsExpandContext&, const MarsRequest&, FlattenCallback&);
+    void expand(const MarsRequest&, ExpandCallback&);
+    void flatten(const MarsRequest&, FlattenCallback&);
 
 private:
 
-    MarsLanguage& language(const MarsExpandContext&, const std::string& verb);
+    MarsLanguage& language(const std::string& verb);
 
     std::map<std::string, MarsLanguage*> languages_;
     bool inherit_;

--- a/src/metkit/mars/MarsLanguage.h
+++ b/src/metkit/mars/MarsLanguage.h
@@ -39,13 +39,13 @@ public:  // methods
 
     ~MarsLanguage();
 
-    MarsRequest expand(const MarsExpandContext& ctx, const MarsRequest& r, bool inherit, bool strict);
+    MarsRequest expand(const MarsRequest& r, bool inherit, bool strict);
 
     void reset();
 
     const std::string& verb() const;
 
-    void flatten(const MarsExpandContext& ctx, const MarsRequest& request, FlattenCallback& callback);
+    void flatten(const MarsRequest& request, FlattenCallback& callback);
 
     static eckit::PathName languageYamlFile();
 
@@ -59,7 +59,7 @@ public:  // methods
 
 public:  // class methods
 
-    static std::string expandVerb(const MarsExpandContext&, const std::string& verb);
+    static std::string expandVerb(const std::string& verb);
 
     static std::string bestMatch(const MarsExpandContext& ctx, const std::string& name,
                                  const std::vector<std::string>& values, bool fail, bool quiet, bool fullMatch,

--- a/src/metkit/mars/Parameter.cc
+++ b/src/metkit/mars/Parameter.cc
@@ -24,7 +24,7 @@ class UndefinedType : public Type {
     void print(std::ostream& out) const override { out << "<undefined type>"; }
 
     bool filter(const std::vector<std::string>&, std::vector<std::string>&) const override { NOTIMP; }
-    bool expand(const MarsExpandContext&, std::string&, const MarsRequest&) const override { NOTIMP; }
+    bool expand(std::string&, const MarsRequest&) const override { NOTIMP; }
 
 public:
 

--- a/src/metkit/mars/Type.cc
+++ b/src/metkit/mars/Type.cc
@@ -281,22 +281,22 @@ std::ostream& operator<<(std::ostream& s, const Type& x) {
     return s;
 }
 
-std::string Type::tidy(const std::string& value, const MarsExpandContext& ctx, const MarsRequest& request) const {
+std::string Type::tidy(const std::string& value, const MarsRequest& request) const {
     std::string result = value;
-    expand(ctx, result, request);
+    expand(result, request);
     return result;
 }
 
-bool Type::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool Type::expand(std::string& value, const MarsRequest&) const {
     std::ostringstream oss;
     oss << *this << ":  expand not implemented (" << value << ")";
     throw eckit::SeriousBug(oss.str());
 }
 
-void Type::expand(const MarsExpandContext& ctx, std::vector<std::string>& values, const MarsRequest& request) const {
+void Type::expand(std::vector<std::string>& values, const MarsRequest& request) const {
 
     if (toByList_ && values.size() > 1) {
-        toByList_->expandRanges(ctx, values, request);
+        toByList_->expandRanges( values, request);
     }
 
     std::vector<std::string> newvals;
@@ -304,9 +304,9 @@ void Type::expand(const MarsExpandContext& ctx, std::vector<std::string>& values
 
     for (std::string& val : values) {
         std::string value = val;
-        if (!expand(ctx, value, request)) {
+        if (!expand(value, request)) {
             std::ostringstream oss;
-            oss << *this << ": cannot expand '" << val << "'" << ctx;
+            oss << *this << ": cannot expand '" << val << "'";
             throw eckit::UserError(oss.str());
         }
         if (hasGroups()) {
@@ -321,7 +321,7 @@ void Type::expand(const MarsExpandContext& ctx, std::vector<std::string>& values
         else {
             if (!duplicates_ && seen.find(value) != seen.end()) {
                 std::ostringstream oss;
-                oss << *this << ": duplicated value '" << value << "'" << ctx;
+                oss << *this << ": duplicated value '" << value << "'";
                 throw eckit::UserError(oss.str());
             }
             newvals.push_back(value);
@@ -382,9 +382,9 @@ const std::string& Type::category() const {
     return category_;
 }
 
-void Type::pass2(const MarsExpandContext& ctx, MarsRequest& request) {}
+void Type::pass2(MarsRequest& request) {}
 
-void Type::finalise(const MarsExpandContext& ctx, MarsRequest& request, bool strict) {
+void Type::finalise(MarsRequest& request, bool strict) {
 
     const std::vector<std::string>& values = request.values(name_, true);
     if (values.size() == 1 && values[0] == "off") {
@@ -434,7 +434,7 @@ void Type::finalise(const MarsExpandContext& ctx, MarsRequest& request, bool str
     }
 }
 
-void Type::check(const MarsExpandContext& ctx, const std::vector<std::string>& values) const {
+void Type::check(const std::vector<std::string>& values) const {
     if (flatten_) {
         std::set<std::string> s(values.begin(), values.end());
         if (values.size() != s.size()) {

--- a/src/metkit/mars/Type.h
+++ b/src/metkit/mars/Type.h
@@ -26,7 +26,6 @@
 #include "eckit/memory/Counted.h"
 #include "eckit/value/Value.h"
 
-#include "metkit/mars/MarsExpandContext.h"
 #include "metkit/mars/MarsRequest.h"
 
 namespace metkit::mars {
@@ -174,7 +173,7 @@ class ITypeToByList {
 public:
 
     virtual ~ITypeToByList()                                    = default;
-    virtual void expandRanges(const MarsExpandContext& ctx, std::vector<std::string>& values,
+    virtual void expandRanges(std::vector<std::string>& values,
                               const MarsRequest& request) const = 0;
 };
 
@@ -187,21 +186,20 @@ public:  // methods
 
     ~Type() noexcept override = default;
 
-    virtual bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request = {}) const;
-    virtual void expand(const MarsExpandContext& ctx, std::vector<std::string>& values,
+    virtual bool expand(std::string& value, const MarsRequest& request = {}) const;
+    virtual void expand(std::vector<std::string>& values,
                         const MarsRequest& request = {}) const;
 
-    std::string tidy(const std::string& value, const MarsExpandContext& ctx = DummyContext{},
-                     const MarsRequest& request = {}) const;
+    std::string tidy(const std::string& value, const MarsRequest& request = {}) const;
 
     virtual void setDefaults(MarsRequest& request);
     virtual void setInheritance(const std::vector<std::string>& inheritance);
-    virtual void check(const MarsExpandContext& ctx, const std::vector<std::string>& values) const;
+    virtual void check(const std::vector<std::string>& values) const;
     virtual void clearDefaults();
     virtual void reset();
 
-    virtual void pass2(const MarsExpandContext& ctx, MarsRequest& request);
-    virtual void finalise(const MarsExpandContext& ctx, MarsRequest& request, bool strict);
+    virtual void pass2(MarsRequest& request);
+    virtual void finalise(MarsRequest& request, bool strict);
 
     virtual const std::vector<std::string>& flattenValues(const MarsRequest& request);
     virtual bool flatten() const;

--- a/src/metkit/mars/TypeAny.cc
+++ b/src/metkit/mars/TypeAny.cc
@@ -22,7 +22,7 @@ void TypeAny::print(std::ostream& out) const {
     out << "TypeAny[name=" << name_ << "]";
 }
 
-bool TypeAny::expand(const MarsExpandContext&, std::string&, const MarsRequest&) const {
+bool TypeAny::expand(std::string&, const MarsRequest&) const {
     return true;
 }
 

--- a/src/metkit/mars/TypeAny.h
+++ b/src/metkit/mars/TypeAny.h
@@ -32,7 +32,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/TypeDate.cc
+++ b/src/metkit/mars/TypeDate.cc
@@ -126,15 +126,15 @@ TypeDate::TypeDate(const std::string& name, const eckit::Value& settings) : Type
     filters_["day"] = &filterByDay;
 }
 
-void TypeDate::pass2(const MarsExpandContext& ctx, MarsRequest& request) {
+void TypeDate::pass2(MarsRequest& request) {
     std::vector<std::string> values = request.values(name_, true);
     if (values.size() == 1 && values[0] == "-1") {
-        Type::expand(ctx, values, request);
+        Type::expand(values, request);
         request.setValuesTyped(this, values);
     }
 }
 
-bool TypeDate::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeDate::expand(std::string& value, const MarsRequest&) const {
     if (!value.empty()) {
         eckit::Translator<std::string, long> s2l;
         eckit::Translator<long, std::string> l2s;

--- a/src/metkit/mars/TypeDate.h
+++ b/src/metkit/mars/TypeDate.h
@@ -33,8 +33,8 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    void pass2(const MarsExpandContext& ctx, MarsRequest& request) override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    void pass2(MarsRequest& request) override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/TypeEnum.cc
+++ b/src/metkit/mars/TypeEnum.cc
@@ -112,7 +112,7 @@ void TypeEnum::print(std::ostream& out) const {
     out << "TypeEnum[name=" << name_ << "]";
 }
 
-bool TypeEnum::expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const {
+bool TypeEnum::expand(std::string& value, const MarsRequest& request) const {
     auto it = find(value);
     if (it == values_.end()) {
         return false;

--- a/src/metkit/mars/TypeEnum.h
+++ b/src/metkit/mars/TypeEnum.h
@@ -39,7 +39,7 @@ private:  // methods
     void print(std::ostream& out) const override;
     void reset() override;
 
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
     std::map<std::string, uint16_t>::const_iterator find(const std::string& value) const;
 
     std::vector<std::string> parseEnumValue(const eckit::Value& val, bool allowDuplicates = false) const;

--- a/src/metkit/mars/TypeExpver.cc
+++ b/src/metkit/mars/TypeExpver.cc
@@ -24,7 +24,7 @@ namespace mars {
 
 TypeExpver::TypeExpver(const std::string& name, const eckit::Value& settings) : Type(name, settings) {}
 
-bool TypeExpver::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeExpver::expand(std::string& value, const MarsRequest&) const {
 
     std::string v = eckit::StringTools::lower(eckit::StringTools::trim(value));
 

--- a/src/metkit/mars/TypeExpver.h
+++ b/src/metkit/mars/TypeExpver.h
@@ -28,7 +28,7 @@ public:  // methods
 
     ~TypeExpver() noexcept override = default;
 
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 
 private:  // methods
 

--- a/src/metkit/mars/TypeFloat.cc
+++ b/src/metkit/mars/TypeFloat.cc
@@ -22,7 +22,7 @@ namespace metkit::mars {
 
 TypeFloat::TypeFloat(const std::string& name, const eckit::Value& settings) : Type(name, settings) {}
 
-bool TypeFloat::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeFloat::expand(std::string& value, const MarsRequest&) const {
 
     bool dot = false;
 

--- a/src/metkit/mars/TypeFloat.h
+++ b/src/metkit/mars/TypeFloat.h
@@ -33,7 +33,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/TypeInteger.cc
+++ b/src/metkit/mars/TypeInteger.cc
@@ -68,7 +68,7 @@ bool TypeInteger::ok(const std::string& value, long& n) const {
     return !range_ || (n >= range_->lower_ && n <= range_->upper_);
 }
 
-bool TypeInteger::expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest&) const {
+bool TypeInteger::expand(std::string& value, const MarsRequest&) const {
     long n = 0;
     if (ok(value, n)) {
         static eckit::Translator<long, std::string> l2s;

--- a/src/metkit/mars/TypeInteger.h
+++ b/src/metkit/mars/TypeInteger.h
@@ -34,7 +34,7 @@ public:  // methods
 protected:
 
     bool ok(const std::string& value, long& n) const;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 
 private:  // methods
 

--- a/src/metkit/mars/TypeLowercase.cc
+++ b/src/metkit/mars/TypeLowercase.cc
@@ -27,7 +27,7 @@ void TypeLowercase::print(std::ostream& out) const {
     out << "TypeLowercase[name=" << name_ << "]";
 }
 
-bool TypeLowercase::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeLowercase::expand(std::string& value, const MarsRequest&) const {
     value = eckit::StringTools::lower(value);
     return true;
 }

--- a/src/metkit/mars/TypeLowercase.h
+++ b/src/metkit/mars/TypeLowercase.h
@@ -31,7 +31,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/TypeMixed.cc
+++ b/src/metkit/mars/TypeMixed.cc
@@ -63,12 +63,12 @@ void TypeMixed::print(std::ostream& out) const {
     out << "]";
 }
 
-bool TypeMixed::expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const {
+bool TypeMixed::expand(std::string& value, const MarsRequest& request) const {
 
     for (auto it = types_.begin(); it != types_.end(); it++) {
         if ((*it).first == nullptr || (*it).first->matches(request)) {
             std::string tmp = value;
-            if ((*it).second->expand(ctx, tmp, request)) {
+            if ((*it).second->expand(tmp, request)) {
                 value = tmp;
                 return true;
             }

--- a/src/metkit/mars/TypeMixed.h
+++ b/src/metkit/mars/TypeMixed.h
@@ -34,7 +34,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 
     std::vector<std::pair<std::unique_ptr<Context>, Type*>> types_;
 };

--- a/src/metkit/mars/TypeParam.cc
+++ b/src/metkit/mars/TypeParam.cc
@@ -87,7 +87,7 @@ class Rule : public metkit::mars::MarsExpandContext {
 public:
 
     bool match(const metkit::mars::MarsRequest& request, bool partial = false) const;
-    std::string lookup(const MarsExpandContext& ctx, const std::string& s, bool fail) const;
+    std::string lookup(const std::string& s, bool fail) const;
     long toParamid(const std::string& param) const;
 
     Rule(const eckit::Value& matchers, const eckit::Value& setters, const eckit::Value& ids);
@@ -252,7 +252,7 @@ public:
 };
 
 
-std::string Rule::lookup(const MarsExpandContext& ctx, const std::string& s, bool fail) const {
+std::string Rule::lookup(const std::string& s, bool fail) const {
 
     size_t table = 0;
     size_t param = 0;
@@ -315,7 +315,7 @@ std::string Rule::lookup(const MarsExpandContext& ctx, const std::string& s, boo
         return p;
     }
 
-    ChainedContext c(ctx, *this);
+    ChainedContext c(metkit::mars::DummyContext(), *this);
 
     std::string paramid = metkit::mars::MarsLanguage::bestMatch(c, s, values_, false, false, true, mapping_);
     if (!paramid.empty()) {
@@ -452,7 +452,7 @@ void TypeParam::print(std::ostream& out) const {
     out << "TypeParam[name=" << name_ << "]";
 }
 
-void TypeParam::pass2(const MarsExpandContext& ctx, MarsRequest& request) {
+void TypeParam::pass2(MarsRequest& request) {
 
     pthread_once(&once, init);
 
@@ -471,7 +471,7 @@ void TypeParam::pass2(const MarsExpandContext& ctx, MarsRequest& request) {
     if (!rule) {
         Log::warning() << "TypeParam: cannot find a context to expand 'param' in " << request << std::endl;
 
-        if (firstRule_) {
+        if (firstRule_){
             bool found = false;
             for (std::vector<Rule>::const_iterator j = rules->begin(); j != rules->end() && !rule; ++j) {
                 const Rule* r = &(*j);
@@ -479,7 +479,7 @@ void TypeParam::pass2(const MarsExpandContext& ctx, MarsRequest& request) {
                     for (std::vector<std::string>::iterator j = values.begin(); j != values.end() && !rule; ++j) {
                         std::string& s = (*j);
                         try {
-                            s    = r->lookup(ctx, s, fail);
+                            s    = r->lookup(s, fail);
                             rule = r;
                             Log::warning() << "TypeParam: using 'first matching rule' option " << *rule << std::endl;
                         }
@@ -515,7 +515,7 @@ void TypeParam::pass2(const MarsExpandContext& ctx, MarsRequest& request) {
     for (std::vector<std::string>::iterator j = values.begin(); j != values.end(); ++j) {
         std::string& s = (*j);
         try {
-            s = rule->lookup(ctx, s, fail);
+            s = rule->lookup(s, fail);
         }
         catch (...) {
             Log::error() << *rule << std::endl;
@@ -526,7 +526,7 @@ void TypeParam::pass2(const MarsExpandContext& ctx, MarsRequest& request) {
     request.setValuesTyped(this, values);
 }
 
-bool TypeParam::expand(const MarsExpandContext&, std::string&, const MarsRequest&) const {
+bool TypeParam::expand(std::string&, const MarsRequest&) const {
     // Work done on pass2()
     return true;
 }

--- a/src/metkit/mars/TypeParam.h
+++ b/src/metkit/mars/TypeParam.h
@@ -36,8 +36,8 @@ private:  // methods
 
     void print(std::ostream& out) const override;
     void reset() override;
-    void pass2(const MarsExpandContext& ctx, MarsRequest& request) override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    void pass2(MarsRequest& request) override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/TypeRange.cc
+++ b/src/metkit/mars/TypeRange.cc
@@ -72,7 +72,7 @@ StepRange TypeRange::parse(const std::string& value) const {
     }
 }
 
-bool TypeRange::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeRange::expand(std::string& value, const MarsRequest&) const {
 
     value = parse(value);
     return true;

--- a/src/metkit/mars/TypeRange.h
+++ b/src/metkit/mars/TypeRange.h
@@ -33,7 +33,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 
     StepRange parse(const std::string& value) const;
 };

--- a/src/metkit/mars/TypeRegex.cc
+++ b/src/metkit/mars/TypeRegex.cc
@@ -39,7 +39,7 @@ TypeRegex::TypeRegex(const std::string& name, const eckit::Value& settings) : Ty
     }
 }
 
-bool TypeRegex::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeRegex::expand(std::string& value, const MarsRequest&) const {
 
     for (std::vector<eckit::Regex>::const_iterator j = regex_.begin(); j != regex_.end(); ++j) {
         if ((*j).match(value)) {

--- a/src/metkit/mars/TypeRegex.h
+++ b/src/metkit/mars/TypeRegex.h
@@ -35,7 +35,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 
     std::vector<eckit::Regex> regex_;
     bool uppercase_;

--- a/src/metkit/mars/TypeTime.cc
+++ b/src/metkit/mars/TypeTime.cc
@@ -26,7 +26,7 @@ TypeTime::TypeTime(const std::string& name, const eckit::Value& settings) : Type
     multiple_ = true;
 }
 
-bool TypeTime::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeTime::expand(std::string& value, const MarsRequest&) const {
 
     eckit::Time time(value);
 

--- a/src/metkit/mars/TypeTime.h
+++ b/src/metkit/mars/TypeTime.h
@@ -34,7 +34,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/metkit/mars/TypeToByList.h
+++ b/src/metkit/mars/TypeToByList.h
@@ -40,8 +40,7 @@ public:  // methods
 
     virtual ~TypeToByList() = default;
 
-    void expandRanges(const MarsExpandContext& ctx, std::vector<std::string>& values,
-                      const MarsRequest& request) const override {
+    void expandRanges(std::vector<std::string>& values, const MarsRequest& request) const override {
 
         if (values.size() == 1) {
             return;
@@ -71,8 +70,8 @@ public:  // methods
                     throw eckit::BadValue(oss.str());
                 }
 
-                EL from = s2el(type_.tidy(values[i - 1], ctx, request));
-                EL to   = s2el(type_.tidy(values[i + 1], ctx, request));
+                EL from = s2el(type_.tidy(values[i - 1], request));
+                EL to   = s2el(type_.tidy(values[i + 1], request));
                 BY by   = s2by(by_);
 
                 if (i + 2 < values.size() && eckit::StringTools::lower(values[i + 2]) == "by") {
@@ -117,12 +116,12 @@ public:  // methods
                     if ((from < to && j > to) || (from > to && j < to)) {
                         break;
                     }
-                    newval.emplace_back(type_.tidy(el2s(j), ctx, request));
+                    newval.emplace_back(type_.tidy(el2s(j), request));
                 }
                 i++;
             }
             else {
-                newval.push_back(type_.tidy(s, ctx, request));
+                newval.push_back(type_.tidy(s, request));
             }
         }
 

--- a/src/metkit/mars/TypeToByListQuantile.cc
+++ b/src/metkit/mars/TypeToByListQuantile.cc
@@ -61,7 +61,7 @@ void TypeToByListQuantile::print(std::ostream& out) const {
     out << "TypeToByListQuantile[name=" << name_ << "]";
 }
 
-bool TypeToByListQuantile::expand(const MarsExpandContext&, std::string& value, const MarsRequest&) const {
+bool TypeToByListQuantile::expand(std::string& value, const MarsRequest&) const {
 
     Quantile q(value);
     if (denominators_.find(q.den()) == denominators_.end()) {

--- a/src/metkit/mars/TypeToByListQuantile.h
+++ b/src/metkit/mars/TypeToByListQuantile.h
@@ -31,7 +31,7 @@ public:  // methods
 private:  // methods
 
     void print(std::ostream& out) const override;
-    bool expand(const MarsExpandContext& ctx, std::string& value, const MarsRequest& request) const override;
+    bool expand(std::string& value, const MarsRequest& request) const override;
 
     std::set<long> denominators_;
 };

--- a/tests/test_date.cc
+++ b/tests/test_date.cc
@@ -33,7 +33,7 @@ using ::eckit::Value;
 void assertTypeExpansion(const std::string& name, std::vector<std::string> values,
                          const std::vector<std::string>& expected) {
     static MarsLanguage language("retrieve");
-    language.type(name)->expand(DummyContext{}, values);
+    language.type(name)->expand(values);
     EXPECT_EQUAL(values.size(), expected.size());
     EXPECT_EQUAL(expected, values);
 }

--- a/tests/test_expand.cc
+++ b/tests/test_expand.cc
@@ -453,16 +453,14 @@ CASE("test_metkit_expand_multirequest-3") {
 }
 
 void expandKeyThrows(const std::string& key, std::vector<std::string> values) {
-    DummyContext ctx;
     static metkit::mars::MarsLanguage language("retrieve");
     metkit::mars::Type* t = language.type(key);
-    EXPECT_THROWS_AS(t->expand(ctx, values), eckit::BadValue);
+    EXPECT_THROWS_AS(t->expand(values), eckit::BadValue);
 }
 void expandKey(const std::string& key, std::vector<std::string> values, std::vector<std::string> expected) {
-    DummyContext ctx;
     static metkit::mars::MarsLanguage language("retrieve");
     metkit::mars::Type* t = language.type(key);
-    t->expand(ctx, values);
+    t->expand(values);
     EXPECT_EQUAL(expected, values);
 }
 

--- a/tests/test_integer_range.cc
+++ b/tests/test_integer_range.cc
@@ -27,8 +27,6 @@ namespace metkit::mars::test {
 using ::eckit::ValueList;
 using ::eckit::ValueMap;
 
-const DummyContext ctx;
-
 //----------------------------------------------------------------------------------------------------------------------
 
 CASE("Test TypeInteger expansion range=[1,100]") {
@@ -43,18 +41,18 @@ CASE("Test TypeInteger expansion range=[1,100]") {
     for (int i = 1; i < 101; ++i) {
         auto num          = std::to_string(i);
         std::string value = num;
-        EXPECT(tday.expand(ctx, value));
+        EXPECT(tday.expand(value));
         EXPECT_EQUAL(value, num);
     }
 
     // out of range
     {
         std::string value = "0";
-        EXPECT(!tday.expand(ctx, value));
+        EXPECT(!tday.expand(value));
     }
     {
         std::string value = "101";
-        EXPECT(!tday.expand(ctx, value));
+        EXPECT(!tday.expand(value));
     }
 }
 
@@ -69,13 +67,13 @@ CASE("Test TypeInteger expansion range=[1,1]") {
 
     {
         std::string value = "1";
-        EXPECT(tday.expand(ctx, value));
+        EXPECT(tday.expand(value));
         EXPECT_EQUAL("1", value);
     }
 
     {
         std::string value = "2";
-        EXPECT(!tday.expand(ctx, value));
+        EXPECT(!tday.expand(value));
     }
 }
 
@@ -90,26 +88,26 @@ CASE("Test TypeInteger day expansion range=[-1,1]") {
 
     {
         std::string value = "-2";
-        EXPECT(!tday.expand(ctx, value));
+        EXPECT(!tday.expand(value));
     }
     {
         std::string value = "-1";
-        EXPECT(tday.expand(ctx, value));
+        EXPECT(tday.expand(value));
         EXPECT_EQUAL("-1", value);
     }
     {
         std::string value = "0";
-        EXPECT(tday.expand(ctx, value));
+        EXPECT(tday.expand(value));
         EXPECT_EQUAL("0", value);
     }
     {
         std::string value = "1";
-        EXPECT(tday.expand(ctx, value));
+        EXPECT(tday.expand(value));
         EXPECT_EQUAL("1", value);
     }
     {
         std::string value = "2";
-        EXPECT(!tday.expand(ctx, value));
+        EXPECT(!tday.expand(value));
     }
 }
 

--- a/tests/test_language.cc
+++ b/tests/test_language.cc
@@ -241,7 +241,7 @@ CASE("check method: flatten()") {
         "500,date=20250717",
         true);
 
-    MarsLanguage("retrieve").flatten(DummyContext(), request, output);
+    MarsLanguage("retrieve").flatten(request, output);
 
     EXPECT_EQUAL(output.oss.str(),
                  "retrieve,class=od,type=an,stream=oper,levtype=pl,date=20250717,time=1200,step=10,levelist=300,param="

--- a/tests/test_obstype.cc
+++ b/tests/test_obstype.cc
@@ -30,7 +30,7 @@ using ::eckit::UserError;
 void assertTypeExpansion(const std::string& name, std::vector<std::string> values,
                          const std::vector<std::string>& expected) {
     static MarsLanguage language("retrieve");
-    language.type(name)->expand(DummyContext{}, values);
+    language.type(name)->expand(values);
     EXPECT_EQUAL(expected, values);
 }
 

--- a/tests/test_step.cc
+++ b/tests/test_step.cc
@@ -30,7 +30,7 @@ using ::eckit::BadValue;
 void assertTypeExpansion(const std::string& name, std::vector<std::string> values,
                          const std::vector<std::string>& expected) {
     static MarsLanguage language("retrieve");
-    language.type(name)->expand(DummyContext{}, values);
+    language.type(name)->expand(values);
     EXPECT_EQUAL(expected, values);
 }
 

--- a/tests/test_time.cc
+++ b/tests/test_time.cc
@@ -34,7 +34,7 @@ using ::eckit::Value;
 void assertTypeExpansion(const std::string& name, std::vector<std::string> values,
                          const std::vector<std::string>& expected) {
     static MarsLanguage language("retrieve");
-    language.type(name)->expand(DummyContext(), values);
+    language.type(name)->expand(values);
     EXPECT_EQUAL(values.size(), expected.size());
     EXPECT_EQUAL(expected, values);
 }

--- a/tests/test_type_levelist.cc
+++ b/tests/test_type_levelist.cc
@@ -38,7 +38,7 @@ CASE("test_metkit_exists_to-by-list-float") {
 void assertTypeExpansion(const std::string& name, std::vector<std::string> values,
                          const std::vector<std::string>& expected) {
     static MarsLanguage language("retrieve");
-    language.type(name)->expand(DummyContext{}, values);
+    language.type(name)->expand(values);
     ASSERT(values == expected);
 }
 


### PR DESCRIPTION
### Description
This is a WIP branch to get rid of the context in all of the expansion methods. The call tree relied on a DummyContext object being passed through several layers of the Code. There was no usage in the inner functions, rendering the object useless. I removed it form the function definitions.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 