### PR TITLE
Fix memory leak in CodesContent::transform.

### DIFF
--- a/src/metkit/codes/CodesContent.cc
+++ b/src/metkit/codes/CodesContent.cc
@@ -190,7 +190,7 @@ eckit::message::MessageContent* CodesContent::transform(const eckit::StringDict&
         throw;
     }
 
-    return new CodesContent(h);
+    return new CodesContent(h, true);
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Fixes a memory leak when using Message::transform with GRIB data. This was found when using fdb-copy with --modifiers (which internally uses ::transform) to transfer data from mn5 HPC to databridge and modify it on the fly.

CodesContent::transform creates a new eccodes handle and returns it wrapped in a new CodesContent instance, but because the delete_handle argument of the CodesContent constructor was left to its default value (false), the handle was never auto-deleted. The Message API currently provides no way for applications to access and delete the handle explicitly, so I'd assume any other applications using Message::transform on GRIB data should also be affected by this.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 