### PR TITLE
Allow adding custom environment values on DHSProto

### DIFF
--- a/src/metkit/mars/DHSProtocol.cc
+++ b/src/metkit/mars/DHSProtocol.cc
@@ -344,6 +344,12 @@ DHSProtocol::DHSProtocol(const Configuration& params) :
     callback_.reset(BaseCallbackConnection::build(params, host_));
 }
 
+DHSProtocol::DHSProtocol(const Configuration& params, const std::map<std::string, std::string>& env) : DHSProtocol(params) {
+    auto requestEnv = RequestEnvironment::instance();
+    requestEnv.update(env);
+    env_ = requestEnv.request();
+}
+
 DHSProtocol::DHSProtocol(Stream& s) : BaseProtocol(s), callback_(Reanimator<BaseCallbackConnection>::reanimate(s)) {
     s >> name_;
     s >> host_;
@@ -352,6 +358,7 @@ DHSProtocol::DHSProtocol(Stream& s) : BaseProtocol(s), callback_(Reanimator<Base
     s >> error_;
     s >> sending_;
     s >> forward_;
+    env_ = MarsRequest(s);
 }
 
 DHSProtocol::~DHSProtocol() {
@@ -373,8 +380,8 @@ Length DHSProtocol::retrieve(const MarsRequest& request) {
 
     LOG_DEBUG_LIB(LibMetkit) << "DHSProtocol: call back on " << callbackEndpoint << std::endl;
 
-    task_.reset(new ClientTask(request, RequestEnvironment::instance().request(), callbackEndpoint.host(),
-                               callbackEndpoint.port()));
+
+    task_.reset(new ClientTask(request, env_, callbackEndpoint.host(), callbackEndpoint.port()));
 
     net::TCPStream s(net::TCPClient().connect(host_, port_));
 
@@ -395,8 +402,7 @@ void DHSProtocol::archive(const MarsRequest& request, const Length& size) {
     LOG_DEBUG_LIB(LibMetkit) << "DHSProtocol::archive " << size << std::endl;
     LOG_DEBUG_LIB(LibMetkit) << "DHSProtocol: call back on " << callbackEndpoint << std::endl;
 
-    task_.reset(new ClientTask(request, RequestEnvironment::instance().request(), callbackEndpoint.host(),
-                               callbackEndpoint.port()));
+    task_.reset(new ClientTask(request, env_, callbackEndpoint.host(), callbackEndpoint.port()));
 
     net::TCPStream s(net::TCPClient().connect(host_, port_));
 
@@ -457,6 +463,7 @@ void DHSProtocol::encode(Stream& s) const {
     s << error_;
     s << sending_;
     s << forward_;
+    s << env_;
 }
 
 long DHSProtocol::read(void* buffer, long len) {

--- a/src/metkit/mars/DHSProtocol.h
+++ b/src/metkit/mars/DHSProtocol.h
@@ -54,6 +54,8 @@ class DHSProtocol : public BaseProtocol {
 public:
 
     DHSProtocol(const eckit::Configuration&);
+    
+    DHSProtocol(const eckit::Configuration&, const std::map<std::string, std::string>& env);
 
     DHSProtocol(const std::string& name, const std::string& host, int port, bool forewardMessages = false);
 
@@ -80,6 +82,7 @@ private:
     bool error_;
     bool sending_;
     bool forward_;
+    MarsRequest env_;
 
     // -- Methods
     bool wait(eckit::Length&);


### PR DESCRIPTION
DHSProtocol now allows passing in custom environment values to be sent to the server.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 