### PR TITLE
Adjust the test data path for Nexus migration

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 
 ecbuild_get_test_multidata( TARGET grib_get_data
-                            DIRNAME grib_api/data
+                            DIRNAME grib-api/test-data/data
                             NAMES latlon.grib
                                   synthetic_2msgs.grib )
 


### PR DESCRIPTION
### Description

Adjust the test data path for Nexus migration. Instead of using https://get.ecmwf.int/repository/test-data/*project*/, the project will now access the data at https://sites.ecmwf.int/repository/*project*/test-data/.

This change also implies the use of the latest ecbuild, with the necessary adjustments to ecbuild_get_test_data/multidata functions.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 