### PR TITLE
mars2grib: remove `__builtin_unreachable()`

### DIFF
--- a/src/metkit/mars2grib/CoreOperations.h
+++ b/src/metkit/mars2grib/CoreOperations.h
@@ -34,7 +34,6 @@
 /// @note: clang-format needs to be off here to preserve the logical grouping of
 /// includes and avoid unnecessary reordering that breaks the layering and dependencies.
 // clang-format off
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/encodeValues.h"

--- a/src/metkit/mars2grib/backend/checks/checkDerivedProductDefinitionSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkDerivedProductDefinitionSection.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -92,8 +91,6 @@ void check_DerivedProductDefinitionSection_or_throw(const OptDict_t& opt, const 
             Mars2GribValidationException("Unable to validate Derived Product Definition Section", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkDerivedProductDefinitionSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkDerivedProductDefinitionSection.h
@@ -90,7 +90,6 @@ void check_DerivedProductDefinitionSection_or_throw(const OptDict_t& opt, const 
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Derived Product Definition Section", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkDestinELocalSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkDestinELocalSection.h
@@ -99,7 +99,6 @@ void check_DestinELocalSection_or_throw(const OptDict_t& opt, const OutDict_t& o
         // Rethrow nested exceptions
         std::throw_with_nested(Mars2GribValidationException("Unable to validate DestinE Local Use Section", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkDestinELocalSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkDestinELocalSection.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -101,8 +100,6 @@ void check_DestinELocalSection_or_throw(const OptDict_t& opt, const OutDict_t& o
         std::throw_with_nested(Mars2GribValidationException("Unable to validate DestinE Local Use Section", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkEnsembleProductDefinitionSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkEnsembleProductDefinitionSection.h
@@ -92,7 +92,6 @@ void check_EnsembleProductDefinitionSection_or_throw(const OptDict_t& opt, const
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Ensemble Product Definition Section", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkEnsembleProductDefinitionSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkEnsembleProductDefinitionSection.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -94,8 +93,6 @@ void check_EnsembleProductDefinitionSection_or_throw(const OptDict_t& opt, const
             Mars2GribValidationException("Unable to validate Ensemble Product Definition Section", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkLocalUseSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkLocalUseSection.h
@@ -85,7 +85,6 @@ void check_LocalUseSection_or_throw(const OptDict_t& opt, const OutDict_t& out) 
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate presence of Local Use Section", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkLocalUseSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkLocalUseSection.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -87,8 +86,6 @@ void check_LocalUseSection_or_throw(const OptDict_t& opt, const OutDict_t& out) 
             Mars2GribValidationException("Unable to validate presence of Local Use Section", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkStatisticsProductDefinitionSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkStatisticsProductDefinitionSection.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -91,8 +90,6 @@ void check_StatisticsProductDefinitionSection_or_throw(const OptDict_t& opt, con
             Mars2GribValidationException("Unable to validate Product Definition Section as Statistics type", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/checkStatisticsProductDefinitionSection.h
+++ b/src/metkit/mars2grib/backend/checks/checkStatisticsProductDefinitionSection.h
@@ -89,7 +89,6 @@ void check_StatisticsProductDefinitionSection_or_throw(const OptDict_t& opt, con
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Product Definition Section as Statistics type", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchDataRepresentationTemplateNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchDataRepresentationTemplateNumber.h
@@ -104,7 +104,6 @@ void match_DataRepresentationTemplateNumber_or_throw(
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Data Representation Template Number", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchDataRepresentationTemplateNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchDataRepresentationTemplateNumber.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -106,8 +105,6 @@ void match_DataRepresentationTemplateNumber_or_throw(
             Mars2GribValidationException("Unable to validate Data Representation Template Number", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchDataset.h
+++ b/src/metkit/mars2grib/backend/checks/matchDataset.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -90,8 +89,6 @@ void match_Dataset_or_throw(const OptDict_t& opt, const OutDict_t& out, const st
         std::throw_with_nested(Mars2GribValidationException("Unable to validate dataset from the sample", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchDataset.h
+++ b/src/metkit/mars2grib/backend/checks/matchDataset.h
@@ -88,7 +88,6 @@ void match_Dataset_or_throw(const OptDict_t& opt, const OutDict_t& out, const st
         // Rethrow nested exceptions
         std::throw_with_nested(Mars2GribValidationException("Unable to validate dataset from the sample", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchGridDefinitionTemplateNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchGridDefinitionTemplateNumber.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -105,8 +104,6 @@ void match_GridDefinitionTemplateNumber_or_throw(const OptDict_t& opt, const Out
             Mars2GribValidationException("Unable to validate Grid Definition Template Number", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchGridDefinitionTemplateNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchGridDefinitionTemplateNumber.h
@@ -103,7 +103,6 @@ void match_GridDefinitionTemplateNumber_or_throw(const OptDict_t& opt, const Out
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Grid Definition Template Number", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchLocalDefinitionNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchLocalDefinitionNumber.h
@@ -112,7 +112,6 @@ void match_LocalDefinitionNumber_or_throw(const OptDict_t& opt, const OutDict_t&
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Local Definition Number in Local Use Section", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchLocalDefinitionNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchLocalDefinitionNumber.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -114,8 +113,6 @@ void match_LocalDefinitionNumber_or_throw(const OptDict_t& opt, const OutDict_t&
             Mars2GribValidationException("Unable to validate Local Definition Number in Local Use Section", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchProductDefinitionTemplateNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchProductDefinitionTemplateNumber.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -107,8 +106,6 @@ void match_ProductDefinitionTemplateNumber_or_throw(const OptDict_t& opt, const 
             Mars2GribValidationException("Unable to validate Product Definition Template Number", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/checks/matchProductDefinitionTemplateNumber.h
+++ b/src/metkit/mars2grib/backend/checks/matchProductDefinitionTemplateNumber.h
@@ -105,7 +105,6 @@ void match_ProductDefinitionTemplateNumber_or_throw(const OptDict_t& opt, const 
         std::throw_with_nested(
             Mars2GribValidationException("Unable to validate Product Definition Template Number", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::validation

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/EntryVariantRegistry.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/EntryVariantRegistry.h
@@ -93,7 +93,6 @@
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/utils.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine {
 

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h
@@ -78,7 +78,6 @@
 
 // Project includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine {
 

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/common.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/common.h
@@ -42,7 +42,6 @@
 #include <utility>
 
 // Project includes
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine {
 

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/makeEntryCallbacksRegistry.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/makeEntryCallbacksRegistry.h
@@ -93,7 +93,6 @@
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/utils.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine {
 

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/makePhaseCallbacksRegistry.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/makePhaseCallbacksRegistry.h
@@ -158,7 +158,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine {
 

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/makeVariantCallbacksRegistry.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/makeVariantCallbacksRegistry.h
@@ -141,7 +141,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine {

--- a/src/metkit/mars2grib/backend/compile-time-registry-engine/utils.h
+++ b/src/metkit/mars2grib/backend/compile-time-registry-engine/utils.h
@@ -80,7 +80,6 @@
 #include <utility>
 
 // Project includes
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::compile_time_registry_engine::detail {
 

--- a/src/metkit/mars2grib/backend/concepts/AllConcepts.h
+++ b/src/metkit/mars2grib/backend/concepts/AllConcepts.h
@@ -90,7 +90,6 @@
 
 // Project includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h"
 #include "metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h"

--- a/src/metkit/mars2grib/backend/concepts/EncodingCallbacksRegistry.h
+++ b/src/metkit/mars2grib/backend/concepts/EncodingCallbacksRegistry.h
@@ -93,7 +93,6 @@
 #include "metkit/mars2grib/backend/compile-time-registry-engine/makePhaseCallbacksRegistry.h"
 #include "metkit/mars2grib/backend/concepts/AllConcepts.h"
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/GeneralRegistry.h
+++ b/src/metkit/mars2grib/backend/concepts/GeneralRegistry.h
@@ -103,7 +103,6 @@
 #include "metkit/mars2grib/backend/compile-time-registry-engine/EntryVariantRegistry.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/AllConcepts.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/MatchingCallbacksRegistry.h
+++ b/src/metkit/mars2grib/backend/concepts/MatchingCallbacksRegistry.h
@@ -97,7 +97,6 @@
 #include "metkit/mars2grib/backend/compile-time-registry-engine/makeEntryCallbacksRegistry.h"
 #include "metkit/mars2grib/backend/concepts/AllConcepts.h"
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/analysis/analysisEncoding.h"
@@ -130,9 +129,6 @@ struct AnalysisConcept : RegisterEntryDescriptor<AnalysisType, AnalysisList> {
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h
@@ -122,7 +122,6 @@ struct AnalysisConcept : RegisterEntryDescriptor<AnalysisType, AnalysisList> {
             if constexpr (analysisApplicable<Stage, Sec, Variant>()) {
                 return &AnalysisOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisConceptDescriptor.h
@@ -122,13 +122,10 @@ struct AnalysisConcept : RegisterEntryDescriptor<AnalysisType, AnalysisList> {
             if constexpr (analysisApplicable<Stage, Sec, Variant>()) {
                 return &AnalysisOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisEncoding.h
@@ -176,7 +176,6 @@ void AnalysisOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& o
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(analysis, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisEncoding.h
@@ -42,7 +42,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/analysis/analysisEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/lengthOfTimeWindow.h"
@@ -178,8 +177,6 @@ void AnalysisOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& o
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(analysis, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/analysis/analysisMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/analysis/analysisMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/analysis/analysisEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h
@@ -122,13 +122,10 @@ struct CompositionConcept : RegisterEntryDescriptor<CompositionType, Composition
             if constexpr (compositionApplicable<Stage, Sec, Variant>()) {
                 return &CompositionOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/composition/compositionEncoding.h"
@@ -130,9 +129,6 @@ struct CompositionConcept : RegisterEntryDescriptor<CompositionType, Composition
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionConceptDescriptor.h
@@ -122,7 +122,6 @@ struct CompositionConcept : RegisterEntryDescriptor<CompositionType, Composition
             if constexpr (compositionApplicable<Stage, Sec, Variant>()) {
                 return &CompositionOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionEncoding.h
@@ -172,7 +172,6 @@ void CompositionOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(composition, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionEncoding.h
@@ -45,7 +45,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/composition/compositionEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/constituentType.h"
@@ -174,8 +173,6 @@ void CompositionOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(composition, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/composition/compositionMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/composition/compositionMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/composition/compositionEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/data-type/dataTypeEncoding.h"
@@ -130,9 +129,6 @@ struct DataTypeConcept : RegisterEntryDescriptor<DataTypeType, DataTypeList> {
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeConceptDescriptor.h
@@ -122,7 +122,6 @@ struct DataTypeConcept : RegisterEntryDescriptor<DataTypeType, DataTypeList> {
             if constexpr (dataTypeApplicable<Stage, Sec, Variant>()) {
                 return &DataTypeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeConceptDescriptor.h
@@ -122,13 +122,10 @@ struct DataTypeConcept : RegisterEntryDescriptor<DataTypeType, DataTypeList> {
             if constexpr (dataTypeApplicable<Stage, Sec, Variant>()) {
                 return &DataTypeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeEncoding.h
@@ -180,7 +180,6 @@ void DataTypeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& o
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(dataType, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeEncoding.h
@@ -49,7 +49,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/data-type/dataTypeEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/productionStatusOfProcessedData.h"
@@ -182,8 +181,6 @@ void DataTypeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& o
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(dataType, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/data-type/dataTypeMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/data-type/dataTypeMatcher.h
@@ -5,7 +5,6 @@
 
 // Utils
 #include "metkit/mars2grib/backend/concepts/data-type/dataTypeEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/derived/derivedEncoding.h"
@@ -130,9 +129,6 @@ struct DerivedConcept : RegisterEntryDescriptor<DerivedType, DerivedList> {
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedConceptDescriptor.h
@@ -122,13 +122,10 @@ struct DerivedConcept : RegisterEntryDescriptor<DerivedType, DerivedList> {
             if constexpr (derivedApplicable<Stage, Sec, Variant>()) {
                 return &DerivedOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedConceptDescriptor.h
@@ -122,7 +122,6 @@ struct DerivedConcept : RegisterEntryDescriptor<DerivedType, DerivedList> {
             if constexpr (derivedApplicable<Stage, Sec, Variant>()) {
                 return &DerivedOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedEncoding.h
@@ -178,7 +178,6 @@ void DerivedOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& op
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(derived, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedEncoding.h
@@ -48,7 +48,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/derived/derivedEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/derivedForecast.h"
@@ -180,8 +179,6 @@ void DerivedOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& op
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(derived, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/derived/derivedMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/derived/derivedMatcher.h
@@ -7,7 +7,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/derived/derivedEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/destine/destineConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/destine/destineEncoding.h"
@@ -130,9 +129,6 @@ struct DestineConcept : RegisterEntryDescriptor<DestineType, DestineList> {
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/destine/destineConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineConceptDescriptor.h
@@ -122,7 +122,6 @@ struct DestineConcept : RegisterEntryDescriptor<DestineType, DestineList> {
             if constexpr (destineApplicable<Stage, Sec, Variant>()) {
                 return &DestineOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/destine/destineConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineConceptDescriptor.h
@@ -122,13 +122,10 @@ struct DestineConcept : RegisterEntryDescriptor<DestineType, DestineList> {
             if constexpr (destineApplicable<Stage, Sec, Variant>()) {
                 return &DestineOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/destine/destineEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineEncoding.h
@@ -55,7 +55,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/destine/destineEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/activity.h"
@@ -230,8 +229,6 @@ void DestineOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& op
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(destine, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/destine/destineEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineEncoding.h
@@ -228,7 +228,6 @@ void DestineOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& op
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(destine, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/destine/destineEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/destine/destineMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/destine/destineMatcher.h
@@ -7,7 +7,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/concepts/destine/destineEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleConceptDescriptor.h
@@ -122,7 +122,6 @@ struct EnsembleConcept : RegisterEntryDescriptor<EnsembleType, EnsembleList> {
             if constexpr (ensembleApplicable<Stage, Sec, Variant>()) {
                 return &EnsembleOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/ensemble/ensembleEncoding.h"
@@ -130,9 +129,6 @@ struct EnsembleConcept : RegisterEntryDescriptor<EnsembleType, EnsembleList> {
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleConceptDescriptor.h
@@ -122,13 +122,10 @@ struct EnsembleConcept : RegisterEntryDescriptor<EnsembleType, EnsembleList> {
             if constexpr (ensembleApplicable<Stage, Sec, Variant>()) {
                 return &EnsembleOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleEncoding.h
@@ -190,7 +190,6 @@ void EnsembleOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& o
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(ensemble, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleEncoding.h
@@ -48,7 +48,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/ensemble/ensembleEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/numberOfForecastsInEnsemble.h"
@@ -192,8 +191,6 @@ void EnsembleOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& o
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(ensemble, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/ensemble/ensembleMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/ensemble/ensembleMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/ensemble/ensembleEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/generating-process/generatingProcessEncoding.h"
@@ -130,9 +129,6 @@ struct GeneratingProcessConcept : RegisterEntryDescriptor<GeneratingProcessType,
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessConceptDescriptor.h
@@ -122,7 +122,6 @@ struct GeneratingProcessConcept : RegisterEntryDescriptor<GeneratingProcessType,
             if constexpr (generatingProcessApplicable<Stage, Sec, Variant>()) {
                 return &GeneratingProcessOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessConceptDescriptor.h
@@ -122,13 +122,10 @@ struct GeneratingProcessConcept : RegisterEntryDescriptor<GeneratingProcessType,
             if constexpr (generatingProcessApplicable<Stage, Sec, Variant>()) {
                 return &GeneratingProcessOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessEncoding.h
@@ -210,8 +210,6 @@ void GeneratingProcessOp(const MarsDict_t& mars, const ParDict_t& par, const Opt
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(generatingProcess, "Concept called when not applicable...");
-
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessEncoding.h
@@ -49,7 +49,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/generating-process/generatingProcessEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Tables
 #include "metkit/mars2grib/backend/tables/backgroundProcess.h"
@@ -213,8 +212,6 @@ void GeneratingProcessOp(const MarsDict_t& mars, const ParDict_t& par, const Opt
     MARS2GRIB_CONCEPT_THROW(generatingProcess, "Concept called when not applicable...");
 
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/generating-process/generatingProcessMatcher.h
@@ -5,7 +5,6 @@
 
 // Utils
 #include "metkit/mars2grib/backend/concepts/generating-process/generatingProcessEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/level/levelConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/level/levelEncoding.h"
@@ -130,9 +129,6 @@ struct LevelConcept : RegisterEntryDescriptor<LevelType, LevelList> {
         else {
             return nullptr;
         }
-
-        // Avoid compiler warnings
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/level/levelConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelConceptDescriptor.h
@@ -122,7 +122,6 @@ struct LevelConcept : RegisterEntryDescriptor<LevelType, LevelList> {
             if constexpr (levelApplicable<Stage, Sec, Variant>()) {
                 return &LevelOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/level/levelConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelConceptDescriptor.h
@@ -122,13 +122,10 @@ struct LevelConcept : RegisterEntryDescriptor<LevelType, LevelList> {
             if constexpr (levelApplicable<Stage, Sec, Variant>()) {
                 return &LevelOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/level/levelEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelEncoding.h
@@ -79,9 +79,7 @@ constexpr bool needPv() {
     if constexpr (Variant == LevelType::Hybrid) {
         return true;
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 ///
@@ -105,9 +103,7 @@ constexpr bool needLevel() {
                   Variant == LevelType::PotentialVorticity || Variant == LevelType::Theta) {
         return true;
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 ///
@@ -127,9 +123,7 @@ constexpr bool needTopBottomLevel() {
                   Variant == LevelType::SnowLayer) {
         return true;
     }
-    else {
-        return false;
-    }
+    return false;
 }
 
 

--- a/src/metkit/mars2grib/backend/concepts/level/levelEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelEncoding.h
@@ -51,7 +51,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/level/levelEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/level.h"
@@ -84,8 +83,6 @@ constexpr bool needPv() {
         return false;
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 ///
@@ -113,8 +110,6 @@ constexpr bool needLevel() {
         return false;
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 ///
@@ -138,8 +133,6 @@ constexpr bool needTopBottomLevel() {
         return false;
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 
@@ -317,8 +310,6 @@ void LevelOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt,
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(level, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/level/levelEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelEncoding.h
@@ -82,7 +82,6 @@ constexpr bool needPv() {
     else {
         return false;
     }
-
 }
 
 ///
@@ -109,7 +108,6 @@ constexpr bool needLevel() {
     else {
         return false;
     }
-
 }
 
 ///
@@ -132,7 +130,6 @@ constexpr bool needTopBottomLevel() {
     else {
         return false;
     }
-
 }
 
 
@@ -309,7 +306,6 @@ void LevelOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt,
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(level, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/level/levelEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/level/levelMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/level/levelMatcher.h
@@ -17,7 +17,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/level/levelEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 #include "metkit/mars2grib/utils/paramMatcher.h"
 

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeConceptDescriptor.h
@@ -122,7 +122,6 @@ struct LongrangeConcept : RegisterEntryDescriptor<LongrangeType, LongrangeList> 
             if constexpr (longrangeApplicable<Stage, Sec, Variant>()) {
                 return &LongrangeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeConceptDescriptor.h
@@ -122,13 +122,10 @@ struct LongrangeConcept : RegisterEntryDescriptor<LongrangeType, LongrangeList> 
             if constexpr (longrangeApplicable<Stage, Sec, Variant>()) {
                 return &LongrangeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/longrange/longrangeEncoding.h"
@@ -130,8 +129,6 @@ struct LongrangeConcept : RegisterEntryDescriptor<LongrangeType, LongrangeList> 
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeEncoding.h
@@ -44,7 +44,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/longrange/longrangeEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/methodNumber.h"
@@ -167,8 +166,6 @@ void LongrangeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(longrange, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeEncoding.h
@@ -165,7 +165,6 @@ void LongrangeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& 
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(longrange, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/longrange/longrangeMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/longrange/longrangeMatcher.h
@@ -7,7 +7,6 @@
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/backend/concepts/longrange/longrangeEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/mars/marsConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/mars/marsEncoding.h"
@@ -130,8 +129,6 @@ struct MarsConcept : RegisterEntryDescriptor<MarsType, MarsList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/mars/marsConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsConceptDescriptor.h
@@ -122,13 +122,10 @@ struct MarsConcept : RegisterEntryDescriptor<MarsType, MarsList> {
             if constexpr (marsApplicable<Stage, Sec, Variant>()) {
                 return &MarsOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/mars/marsConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsConceptDescriptor.h
@@ -122,7 +122,6 @@ struct MarsConcept : RegisterEntryDescriptor<MarsType, MarsList> {
             if constexpr (marsApplicable<Stage, Sec, Variant>()) {
                 return &MarsOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/mars/marsEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsEncoding.h
@@ -197,7 +197,6 @@ void MarsOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt, 
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(mars, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/mars/marsEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsEncoding.h
@@ -49,7 +49,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/mars/marsEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/class.h"
@@ -199,8 +198,6 @@ void MarsOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt, 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(mars, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/mars/marsEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/mars/marsMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/mars/marsMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/mars/marsEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/nil/nilConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilConceptDescriptor.h
@@ -122,13 +122,10 @@ struct NilConcept : RegisterEntryDescriptor<NilType, NilList> {
             if constexpr (nilApplicable<Stage, Sec, Variant>()) {
                 return &NilOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/nil/nilConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilConceptDescriptor.h
@@ -122,7 +122,6 @@ struct NilConcept : RegisterEntryDescriptor<NilType, NilList> {
             if constexpr (nilApplicable<Stage, Sec, Variant>()) {
                 return &NilOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/nil/nilConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/nil/nilEncoding.h"
@@ -130,8 +129,6 @@ struct NilConcept : RegisterEntryDescriptor<NilType, NilList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     ///

--- a/src/metkit/mars2grib/backend/concepts/nil/nilEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilEncoding.h
@@ -39,7 +39,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/nil/nilEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Utils
 #include "metkit/config/LibMetkit.h"
@@ -119,8 +118,6 @@ void NilOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt, O
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(nil, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/nil/nilEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilEncoding.h
@@ -117,7 +117,6 @@ void NilOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt, O
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(nil, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/nil/nilEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/nil/nilMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/nil/nilMatcher.h
@@ -5,7 +5,6 @@
 
 // Utils
 #include "metkit/mars2grib/backend/concepts/nil/nilEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/origin/originConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originConceptDescriptor.h
@@ -72,7 +72,6 @@ struct OriginConcept : RegisterEntryDescriptor<OriginType, OriginList> {
             if constexpr (originApplicable<Stage, Sec, Variant>()) {
                 return &OriginOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/origin/originConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originConceptDescriptor.h
@@ -72,13 +72,10 @@ struct OriginConcept : RegisterEntryDescriptor<OriginType, OriginList> {
             if constexpr (originApplicable<Stage, Sec, Variant>()) {
                 return &OriginOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, OriginType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/origin/originConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/origin/originEncoding.h"
@@ -80,8 +79,6 @@ struct OriginConcept : RegisterEntryDescriptor<OriginType, OriginList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, OriginType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/origin/originEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originEncoding.h
@@ -43,7 +43,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/origin/originEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/centre.h"
@@ -147,8 +146,6 @@ void OriginOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(origin, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/origin/originEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originEncoding.h
@@ -145,7 +145,6 @@ void OriginOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(origin, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/origin/originEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/origin/originMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/origin/originMatcher.h
@@ -5,7 +5,6 @@
 
 // Utils
 #include "metkit/mars2grib/backend/concepts/origin/originEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/packing/packingConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingConceptDescriptor.h
@@ -72,13 +72,10 @@ struct PackingConcept : RegisterEntryDescriptor<PackingType, PackingList> {
             if constexpr (packingApplicable<Stage, Sec, Variant>()) {
                 return &PackingOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, PackingType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/packing/packingConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/packing/packingEncoding.h"
@@ -80,8 +79,6 @@ struct PackingConcept : RegisterEntryDescriptor<PackingType, PackingList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, PackingType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/packing/packingConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingConceptDescriptor.h
@@ -72,7 +72,6 @@ struct PackingConcept : RegisterEntryDescriptor<PackingType, PackingList> {
             if constexpr (packingApplicable<Stage, Sec, Variant>()) {
                 return &PackingOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/packing/packingEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingEncoding.h
@@ -206,7 +206,6 @@ void PackingOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& op
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(packing, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/packing/packingEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingEncoding.h
@@ -48,7 +48,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/packing/packingEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Checks
 #include "metkit/mars2grib/backend/checks/matchDataRepresentationTemplateNumber.h"
@@ -208,8 +207,6 @@ void PackingOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& op
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(packing, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/packing/packingEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/packing/packingMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/packing/packingMatcher.h
@@ -7,7 +7,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/concepts/packing/packingEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/param/paramConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramConceptDescriptor.h
@@ -72,7 +72,6 @@ struct ParamConcept : RegisterEntryDescriptor<ParamType, ParamList> {
             if constexpr (paramApplicable<Stage, Sec, Variant>()) {
                 return &ParamOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/param/paramConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/param/paramEncoding.h"
@@ -80,8 +79,6 @@ struct ParamConcept : RegisterEntryDescriptor<ParamType, ParamList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, ParamType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/param/paramConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramConceptDescriptor.h
@@ -72,13 +72,10 @@ struct ParamConcept : RegisterEntryDescriptor<ParamType, ParamList> {
             if constexpr (paramApplicable<Stage, Sec, Variant>()) {
                 return &ParamOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, ParamType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/param/paramEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramEncoding.h
@@ -42,7 +42,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/param/paramEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/paramId.h"
@@ -151,8 +150,6 @@ void ParamOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt,
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(param, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/param/paramEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramEncoding.h
@@ -149,7 +149,6 @@ void ParamOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt,
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(param, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/param/paramEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/param/paramMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/param/paramMatcher.h
@@ -5,7 +5,6 @@
 
 // Utils
 #include "metkit/mars2grib/backend/concepts/param/paramEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeConceptDescriptor.h
@@ -72,7 +72,6 @@ struct PointInTimeConcept : RegisterEntryDescriptor<PointInTimeType, PointInTime
             if constexpr (pointInTimeApplicable<Stage, Sec, Variant>()) {
                 return &PointInTimeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeConceptDescriptor.h
@@ -72,13 +72,10 @@ struct PointInTimeConcept : RegisterEntryDescriptor<PointInTimeType, PointInTime
             if constexpr (pointInTimeApplicable<Stage, Sec, Variant>()) {
                 return &PointInTimeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, PointInTimeType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEncoding.h"
@@ -80,8 +79,6 @@ struct PointInTimeConcept : RegisterEntryDescriptor<PointInTimeType, PointInTime
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, PointInTimeType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEncoding.h
@@ -47,7 +47,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Tables
 #include "metkit/mars2grib/backend/tables/timeUnits.h"
@@ -198,8 +197,6 @@ void PointInTimeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(pointInTime, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEncoding.h
@@ -196,7 +196,6 @@ void PointInTimeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(pointInTime, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/point-in-time/pointInTimeMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/point-in-time/pointInTimeEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/paramMatcher.h"
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeConceptDescriptor.h
@@ -72,13 +72,10 @@ struct ReferenceTimeConcept : RegisterEntryDescriptor<ReferenceTimeType, Referen
             if constexpr (referenceTimeApplicable<Stage, Sec, Variant>()) {
                 return &ReferenceTimeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, ReferenceTimeType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeConceptDescriptor.h
@@ -72,7 +72,6 @@ struct ReferenceTimeConcept : RegisterEntryDescriptor<ReferenceTimeType, Referen
             if constexpr (referenceTimeApplicable<Stage, Sec, Variant>()) {
                 return &ReferenceTimeOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h"
@@ -80,8 +79,6 @@ struct ReferenceTimeConcept : RegisterEntryDescriptor<ReferenceTimeType, Referen
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, ReferenceTimeType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h
@@ -247,7 +247,6 @@ void ReferenceTimeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(referenceTime, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h
@@ -59,7 +59,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/reference-time/referenceTimeEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/hindcastDateTime.h"
@@ -249,8 +248,6 @@ void ReferenceTimeOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(referenceTime, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/reference-time/referenceTimeEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/representation/representationConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationConceptDescriptor.h
@@ -72,13 +72,10 @@ struct RepresentationConcept : RegisterEntryDescriptor<RepresentationType, Repre
             if constexpr (representationApplicable<Stage, Sec, Variant>()) {
                 return &RepresentationOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, RepresentationType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/representation/representationConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/representation/representationEncoding.h"
@@ -80,8 +79,6 @@ struct RepresentationConcept : RegisterEntryDescriptor<RepresentationType, Repre
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, RepresentationType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/representation/representationConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationConceptDescriptor.h
@@ -72,7 +72,6 @@ struct RepresentationConcept : RegisterEntryDescriptor<RepresentationType, Repre
             if constexpr (representationApplicable<Stage, Sec, Variant>()) {
                 return &RepresentationOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
@@ -132,7 +132,6 @@
 #include "eckit/geo/grid/regular/RegularGaussian.h"
 #include "eckit/geo/grid/regular/RegularLL.h"
 #include "eckit/spec/Custom.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 // Core concept includes
@@ -467,8 +466,6 @@ void RepresentationOp(const MarsDict_t& mars, const ParDict_t& par, const OptDic
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(representation, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
@@ -465,7 +465,6 @@ void RepresentationOp(const MarsDict_t& mars, const ParDict_t& par, const OptDic
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(representation, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/representation/representationEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/representation/representationMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationMatcher.h
@@ -8,7 +8,6 @@
 #include "eckit/spec/Custom.h"
 #include "metkit/mars2grib/backend/concepts/representation/representationEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteConceptDescriptor.h
@@ -72,13 +72,10 @@ struct SatelliteConcept : RegisterEntryDescriptor<SatelliteType, SatelliteList> 
             if constexpr (satelliteApplicable<Stage, Sec, Variant>()) {
                 return &SatelliteOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, SatelliteType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/satellite/satelliteEncoding.h"
@@ -80,8 +79,6 @@ struct SatelliteConcept : RegisterEntryDescriptor<SatelliteType, SatelliteList> 
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, SatelliteType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteConceptDescriptor.h
@@ -72,7 +72,6 @@ struct SatelliteConcept : RegisterEntryDescriptor<SatelliteType, SatelliteList> 
             if constexpr (satelliteApplicable<Stage, Sec, Variant>()) {
                 return &SatelliteOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteEncoding.h
@@ -265,7 +265,6 @@ void SatelliteOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& 
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(satellite, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteEncoding.h
@@ -108,7 +108,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/satellite/satelliteEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Checks
 #include "metkit/mars2grib/backend/checks/matchLocalDefinitionNumber.h"
@@ -267,8 +266,6 @@ void SatelliteOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(satellite, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/satellite/satelliteMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/satellite/satelliteMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/satellite/satelliteEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthConceptDescriptor.h
@@ -72,7 +72,6 @@ struct ShapeOfTheEarthConcept : RegisterEntryDescriptor<ShapeOfTheEarthType, Sha
             if constexpr (shapeOfTheEarthApplicable<Stage, Sec, Variant>()) {
                 return &ShapeOfTheEarthOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthConceptDescriptor.h
@@ -72,13 +72,10 @@ struct ShapeOfTheEarthConcept : RegisterEntryDescriptor<ShapeOfTheEarthType, Sha
             if constexpr (shapeOfTheEarthApplicable<Stage, Sec, Variant>()) {
                 return &ShapeOfTheEarthOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, ShapeOfTheEarthType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEncoding.h"
@@ -80,8 +79,6 @@ struct ShapeOfTheEarthConcept : RegisterEntryDescriptor<ShapeOfTheEarthType, Sha
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, ShapeOfTheEarthType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEncoding.h
@@ -152,7 +152,6 @@ void ShapeOfTheEarthOp(const MarsDict_t& mars, const ParDict_t& par, const OptDi
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(shapeOfTheEarth, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEncoding.h
@@ -43,7 +43,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/shapeOfTheEarth.h"
@@ -154,8 +153,6 @@ void ShapeOfTheEarthOp(const MarsDict_t& mars, const ParDict_t& par, const OptDi
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(shapeOfTheEarth, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthMatcher.h
@@ -7,7 +7,6 @@
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/shape-of-the-earth/shapeOfTheEarthEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsConceptDescriptor.h
@@ -72,7 +72,6 @@ struct StatisticsConcept : RegisterEntryDescriptor<StatisticsType, StatisticsLis
             if constexpr (statisticsApplicable<Stage, Sec, Variant>()) {
                 return &StatisticsOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsConceptDescriptor.h
@@ -72,13 +72,10 @@ struct StatisticsConcept : RegisterEntryDescriptor<StatisticsType, StatisticsLis
             if constexpr (statisticsApplicable<Stage, Sec, Variant>()) {
                 return &StatisticsOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, StatisticsType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/statistics/statisticsEncoding.h"
@@ -80,8 +79,6 @@ struct StatisticsConcept : RegisterEntryDescriptor<StatisticsType, StatisticsLis
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, StatisticsType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsEncoding.h
@@ -271,7 +271,6 @@ void StatisticsOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t&
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(statistics, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsEncoding.h
@@ -53,7 +53,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/statistics/statisticsEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/forecastTimeInSeconds.h"
@@ -273,8 +272,6 @@ void StatisticsOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t&
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(statistics, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsEnum.h
@@ -45,7 +45,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/statistics/statisticsMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/statistics/statisticsMatcher.h
@@ -7,7 +7,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/statistics/statisticsEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 #include "metkit/mars2grib/utils/paramMatcher.h"
 

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesConceptDescriptor.h
@@ -72,13 +72,10 @@ struct TablesConcept : RegisterEntryDescriptor<TablesType, TablesList> {
             if constexpr (tablesApplicable<Stage, Sec, Variant>()) {
                 return &TablesOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, TablesType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/tables/tablesEncoding.h"
@@ -80,8 +79,6 @@ struct TablesConcept : RegisterEntryDescriptor<TablesType, TablesList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, TablesType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesConceptDescriptor.h
@@ -72,7 +72,6 @@ struct TablesConcept : RegisterEntryDescriptor<TablesType, TablesList> {
             if constexpr (tablesApplicable<Stage, Sec, Variant>()) {
                 return &TablesOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesEncoding.h
@@ -198,7 +198,6 @@ void TablesOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(tables, "Concept called when not applicable...");
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesEncoding.h
@@ -48,7 +48,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/tables/tablesEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/localTablesVersion.h"
@@ -200,8 +199,6 @@ void TablesOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(tables, "Concept called when not applicable...");
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/tables/tablesMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/tables/tablesMatcher.h
@@ -6,7 +6,6 @@
 // Utils
 #include "metkit/mars2grib/backend/concepts/tables/tablesEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/paramMatcher.h"
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/concepts/wave/waveConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveConceptDescriptor.h
@@ -35,7 +35,6 @@
 // Registry engine
 #include "metkit/mars2grib/backend/compile-time-registry-engine/RegisterEntryDescriptor.h"
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core concept includes
 #include "metkit/mars2grib/backend/concepts/wave/waveEncoding.h"
@@ -80,8 +79,6 @@ struct WaveConcept : RegisterEntryDescriptor<WaveType, WaveList> {
         else {
             return nullptr;
         }
-
-        mars2gribUnreachable();
     }
 
     template <std::size_t Capability, WaveType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/wave/waveConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveConceptDescriptor.h
@@ -72,7 +72,6 @@ struct WaveConcept : RegisterEntryDescriptor<WaveType, WaveList> {
             if constexpr (waveApplicable<Stage, Sec, Variant>()) {
                 return &WaveOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-
         }
 
         return nullptr;

--- a/src/metkit/mars2grib/backend/concepts/wave/waveConceptDescriptor.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveConceptDescriptor.h
@@ -72,13 +72,10 @@ struct WaveConcept : RegisterEntryDescriptor<WaveType, WaveList> {
             if constexpr (waveApplicable<Stage, Sec, Variant>()) {
                 return &WaveOp<Stage, Sec, Variant, MarsDict_t, ParDict_t, OptDict_t, OutDict_t>;
             }
-            else {
-                return nullptr;
-            }
+
         }
-        else {
-            return nullptr;
-        }
+
+        return nullptr;
     }
 
     template <std::size_t Capability, WaveType Variant, class MarsDict_t, class ParDict_t, class OptDict_t,

--- a/src/metkit/mars2grib/backend/concepts/wave/waveEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveEncoding.h
@@ -50,7 +50,6 @@
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
 #include "metkit/mars2grib/backend/concepts/wave/waveEnum.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/periodItMax.h"
@@ -298,8 +297,6 @@ void WaveOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt, 
     MARS2GRIB_CONCEPT_THROW(wave, "Concept called when not applicable...");
 
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/wave/waveEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveEncoding.h
@@ -295,8 +295,6 @@ void WaveOp(const MarsDict_t& mars, const ParDict_t& par, const OptDict_t& opt, 
 
     // Concept invoked outside its applicability domain
     MARS2GRIB_CONCEPT_THROW(wave, "Concept called when not applicable...");
-
-
 }
 
 }  // namespace metkit::mars2grib::backend::concepts_

--- a/src/metkit/mars2grib/backend/concepts/wave/waveEnum.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveEnum.h
@@ -43,7 +43,6 @@
 
 // Core concept includes
 #include "metkit/mars2grib/backend/compile-time-registry-engine/common.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::concepts_ {
 

--- a/src/metkit/mars2grib/backend/concepts/wave/waveMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/wave/waveMatcher.h
@@ -7,7 +7,6 @@
 #include "eckit/exception/Exceptions.h"
 #include "metkit/mars2grib/backend/concepts/wave/waveEnum.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/paramMatcher.h"
 
 namespace metkit::mars2grib::backend::concepts_ {

--- a/src/metkit/mars2grib/backend/deductions/activity.h
+++ b/src/metkit/mars2grib/backend/deductions/activity.h
@@ -54,7 +54,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -134,8 +133,6 @@ std::string resolve_Activity_or_throw(const MarsDict_t& mars, [[maybe_unused]] c
             Mars2GribDeductionException("Failed to resolve `activity` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/activity.h
+++ b/src/metkit/mars2grib/backend/deductions/activity.h
@@ -132,7 +132,6 @@ std::string resolve_Activity_or_throw(const MarsDict_t& mars, [[maybe_unused]] c
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `activity` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/allowedReferenceValue.h
+++ b/src/metkit/mars2grib/backend/deductions/allowedReferenceValue.h
@@ -58,7 +58,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -220,8 +219,6 @@ double resolve_AllowedReferenceValue_or_throw(const MarsDict_t& mars, const ParD
             Mars2GribDeductionException("Failed to resolve `allowedReferenceValue` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/allowedReferenceValue.h
+++ b/src/metkit/mars2grib/backend/deductions/allowedReferenceValue.h
@@ -218,7 +218,6 @@ double resolve_AllowedReferenceValue_or_throw(const MarsDict_t& mars, const ParD
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `allowedReferenceValue` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/backgroundProcess.h
+++ b/src/metkit/mars2grib/backend/deductions/backgroundProcess.h
@@ -172,7 +172,6 @@ tables::BackgroundProcess resolve_BackgroundProcess_or_throw(const MarsDict_t& m
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `backgroundProcess` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/backgroundProcess.h
+++ b/src/metkit/mars2grib/backend/deductions/backgroundProcess.h
@@ -55,7 +55,6 @@
 
 // Tables
 #include "metkit/mars2grib/backend/tables/backgroundProcess.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -174,8 +173,6 @@ tables::BackgroundProcess resolve_BackgroundProcess_or_throw(const MarsDict_t& m
             Mars2GribDeductionException("Failed to resolve `backgroundProcess` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/bitsPerValue.h
+++ b/src/metkit/mars2grib/backend/deductions/bitsPerValue.h
@@ -64,7 +64,6 @@
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -297,8 +296,6 @@ long resolve_BitsPerValueGridded_or_throw(const MarsDict_t& mars, const ParDict_
             Mars2GribDeductionException("Failed to resolve `bitsPerValue` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 
@@ -402,8 +399,6 @@ long resolve_BitsPerValueSpectral_or_throw(const MarsDict_t& mars, const ParDict
             Mars2GribDeductionException("Failed to resolve `bitsPerValue` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/bitsPerValue.h
+++ b/src/metkit/mars2grib/backend/deductions/bitsPerValue.h
@@ -295,7 +295,6 @@ long resolve_BitsPerValueGridded_or_throw(const MarsDict_t& mars, const ParDict_
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `bitsPerValue` from input dictionaries", Here()));
     };
-
 };
 
 
@@ -398,7 +397,6 @@ long resolve_BitsPerValueSpectral_or_throw(const MarsDict_t& mars, const ParDict
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `bitsPerValue` from input dictionaries", Here()));
     };
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/centre.h
+++ b/src/metkit/mars2grib/backend/deductions/centre.h
@@ -54,7 +54,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/backend/deductions/channel.h
+++ b/src/metkit/mars2grib/backend/deductions/channel.h
@@ -135,7 +135,6 @@ long resolve_Channel_or_throw(const MarsDict_t& mars, const ParDict_t& par, cons
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `channel` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/channel.h
+++ b/src/metkit/mars2grib/backend/deductions/channel.h
@@ -56,7 +56,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -137,8 +136,6 @@ long resolve_Channel_or_throw(const MarsDict_t& mars, const ParDict_t& par, cons
             Mars2GribDeductionException("Failed to resolve `channel` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/class.h
+++ b/src/metkit/mars2grib/backend/deductions/class.h
@@ -134,7 +134,6 @@ std::string resolve_Class_or_throw(const MarsDict_t& mars, const ParDict_t& par,
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `class` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/class.h
+++ b/src/metkit/mars2grib/backend/deductions/class.h
@@ -56,7 +56,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -136,8 +135,6 @@ std::string resolve_Class_or_throw(const MarsDict_t& mars, const ParDict_t& par,
             Mars2GribDeductionException("Failed to resolve `class` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/constituentType.h
+++ b/src/metkit/mars2grib/backend/deductions/constituentType.h
@@ -55,7 +55,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -148,8 +147,6 @@ long resolve_ConstituentType_or_throw(const MarsDict_t& mars, const ParDict_t& p
             Mars2GribDeductionException("Failed to resolve `constituentType` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/constituentType.h
+++ b/src/metkit/mars2grib/backend/deductions/constituentType.h
@@ -146,7 +146,6 @@ long resolve_ConstituentType_or_throw(const MarsDict_t& mars, const ParDict_t& p
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `constituentType` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/dataset.h
+++ b/src/metkit/mars2grib/backend/deductions/dataset.h
@@ -59,7 +59,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -139,8 +138,6 @@ std::string resolve_Dataset_or_throw(const MarsDict_t& mars, const ParDict_t& pa
             Mars2GribDeductionException("Failed to resolve `dataset` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/dataset.h
+++ b/src/metkit/mars2grib/backend/deductions/dataset.h
@@ -137,7 +137,6 @@ std::string resolve_Dataset_or_throw(const MarsDict_t& mars, const ParDict_t& pa
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `dataset` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/derivedForecast.h
+++ b/src/metkit/mars2grib/backend/deductions/derivedForecast.h
@@ -53,7 +53,6 @@
 
 // Tables
 #include "metkit/mars2grib/backend/tables/derivedForecast.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -173,8 +172,6 @@ tables::DerivedForecast resolve_DerivedForecast_or_throw(const MarsDict_t& mars,
             Mars2GribDeductionException("Failed to resolve `derivedForecast` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/derivedForecast.h
+++ b/src/metkit/mars2grib/backend/deductions/derivedForecast.h
@@ -171,7 +171,6 @@ tables::DerivedForecast resolve_DerivedForecast_or_throw(const MarsDict_t& mars,
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `derivedForecast` from input dictionaries", Here()));
     };
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/detail/pv_137_be.h
+++ b/src/metkit/mars2grib/backend/deductions/detail/pv_137_be.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // namespace metkit::mars2grib::backend::deductions::pv_detail::data {
 

--- a/src/metkit/mars2grib/backend/deductions/detail/timeUtils.h
+++ b/src/metkit/mars2grib/backend/deductions/detail/timeUtils.h
@@ -8,7 +8,6 @@
 
 #include <eckit/types/DateTime.h>
 #include "eckit/exception/Exceptions.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::deductions::detail {
 

--- a/src/metkit/mars2grib/backend/deductions/experiment.h
+++ b/src/metkit/mars2grib/backend/deductions/experiment.h
@@ -59,7 +59,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -139,8 +138,6 @@ std::string resolve_Experiment_or_throw(const MarsDict_t& mars, const ParDict_t&
             Mars2GribDeductionException("Failed to resolve `experiment` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/experiment.h
+++ b/src/metkit/mars2grib/backend/deductions/experiment.h
@@ -137,7 +137,6 @@ std::string resolve_Experiment_or_throw(const MarsDict_t& mars, const ParDict_t&
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `experiment` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/expver.h
+++ b/src/metkit/mars2grib/backend/deductions/expver.h
@@ -57,7 +57,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -137,8 +136,6 @@ std::string resolve_Expver_or_throw(const MarsDict_t& mars, const ParDict_t& par
             Mars2GribDeductionException("Failed to resolve `expver` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/expver.h
+++ b/src/metkit/mars2grib/backend/deductions/expver.h
@@ -135,7 +135,6 @@ std::string resolve_Expver_or_throw(const MarsDict_t& mars, const ParDict_t& par
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `expver` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/forecastTimeInSeconds.h
+++ b/src/metkit/mars2grib/backend/deductions/forecastTimeInSeconds.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/logUtils.h"
@@ -108,8 +107,6 @@ long resolve_ForecastTimeInSeconds_or_throw(const MarsDict_t& mars, const ParDic
         std::throw_with_nested(Mars2GribDeductionException("Unable to compute forecast time", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/forecastTimeInSeconds.h
+++ b/src/metkit/mars2grib/backend/deductions/forecastTimeInSeconds.h
@@ -106,7 +106,6 @@ long resolve_ForecastTimeInSeconds_or_throw(const MarsDict_t& mars, const ParDic
         // Rethrow nested exceptions
         std::throw_with_nested(Mars2GribDeductionException("Unable to compute forecast time", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/generatingProcessIdentifier.h
+++ b/src/metkit/mars2grib/backend/deductions/generatingProcessIdentifier.h
@@ -121,7 +121,6 @@ std::optional<long> resolve_GeneratingProcessIdentifier_opt([[maybe_unused]] con
         std::throw_with_nested(Mars2GribDeductionException(
             "Unable to get `generatingProcessIdentifier` from parameter dictionary", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/generatingProcessIdentifier.h
+++ b/src/metkit/mars2grib/backend/deductions/generatingProcessIdentifier.h
@@ -14,7 +14,6 @@
 
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
@@ -123,8 +122,6 @@ std::optional<long> resolve_GeneratingProcessIdentifier_opt([[maybe_unused]] con
             "Unable to get `generatingProcessIdentifier` from parameter dictionary", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/generation.h
+++ b/src/metkit/mars2grib/backend/deductions/generation.h
@@ -59,7 +59,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -139,8 +138,6 @@ long resolve_Generation_or_throw(const MarsDict_t& mars, const ParDict_t& par, c
             Mars2GribDeductionException("Failed to resolve `generation` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/generation.h
+++ b/src/metkit/mars2grib/backend/deductions/generation.h
@@ -137,7 +137,6 @@ long resolve_Generation_or_throw(const MarsDict_t& mars, const ParDict_t& par, c
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `generation` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/hindcastDateTime.h
+++ b/src/metkit/mars2grib/backend/deductions/hindcastDateTime.h
@@ -15,7 +15,6 @@
 #include "eckit/types/Date.h"
 #include "eckit/types/DateTime.h"
 #include "eckit/types/Time.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/mars2grib/backend/deductions/detail/timeUtils.h"
 
@@ -123,8 +122,6 @@ eckit::DateTime resolve_HindcastDateTime_or_throw(const MarsDict_t& mars, const 
             "Unable to get `date` and `time` from Mars dictionary to deduce `dateTime`", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/hindcastDateTime.h
+++ b/src/metkit/mars2grib/backend/deductions/hindcastDateTime.h
@@ -121,7 +121,6 @@ eckit::DateTime resolve_HindcastDateTime_or_throw(const MarsDict_t& mars, const 
         std::throw_with_nested(Mars2GribDeductionException(
             "Unable to get `date` and `time` from Mars dictionary to deduce `dateTime`", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/instrumentType.h
+++ b/src/metkit/mars2grib/backend/deductions/instrumentType.h
@@ -137,7 +137,6 @@ long resolve_InstrumentType_or_throw(const MarsDict_t& mars, const ParDict_t& pa
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `instrumentType` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/instrumentType.h
+++ b/src/metkit/mars2grib/backend/deductions/instrumentType.h
@@ -58,7 +58,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -139,8 +138,6 @@ long resolve_InstrumentType_or_throw(const MarsDict_t& mars, const ParDict_t& pa
             Mars2GribDeductionException("Failed to resolve `instrumentType` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/laplacianOperator.h
+++ b/src/metkit/mars2grib/backend/deductions/laplacianOperator.h
@@ -133,7 +133,6 @@ double resolve_LaplacianOperator_or_throw(const MarsDict_t& mars, const ParDict_
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `laplacianOperator` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/laplacianOperator.h
+++ b/src/metkit/mars2grib/backend/deductions/laplacianOperator.h
@@ -56,7 +56,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -135,8 +134,6 @@ double resolve_LaplacianOperator_or_throw(const MarsDict_t& mars, const ParDict_
             Mars2GribDeductionException("Failed to resolve `laplacianOperator` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/lengthOfTimeWindow.h
+++ b/src/metkit/mars2grib/backend/deductions/lengthOfTimeWindow.h
@@ -59,7 +59,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -164,8 +163,6 @@ std::optional<long> resolve_LengthOfTimeWindowInSeconds_or_throw(const MarsDict_
             Mars2GribDeductionException("Unable to get `lengthOfTimeWindow` from Par dictionary", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/lengthOfTimeWindow.h
+++ b/src/metkit/mars2grib/backend/deductions/lengthOfTimeWindow.h
@@ -162,7 +162,6 @@ std::optional<long> resolve_LengthOfTimeWindowInSeconds_or_throw(const MarsDict_
         std::throw_with_nested(
             Mars2GribDeductionException("Unable to get `lengthOfTimeWindow` from Par dictionary", Here()));
     };
-
 }
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/level.h
+++ b/src/metkit/mars2grib/backend/deductions/level.h
@@ -59,7 +59,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -140,8 +139,6 @@ long resolve_Level_or_throw(const MarsDict_t& mars, const ParDict_t& par, const 
             Mars2GribDeductionException("Failed to resolve `levelist` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/level.h
+++ b/src/metkit/mars2grib/backend/deductions/level.h
@@ -138,7 +138,6 @@ long resolve_Level_or_throw(const MarsDict_t& mars, const ParDict_t& par, const 
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `levelist` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/localTablesVersion.h
+++ b/src/metkit/mars2grib/backend/deductions/localTablesVersion.h
@@ -54,7 +54,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/backend/deductions/methodNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/methodNumber.h
@@ -53,7 +53,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/logUtils.h"
@@ -135,8 +134,6 @@ long resolve_MethodNumber_or_throw(const MarsDict_t& mars, const ParDict_t& par,
             Mars2GribDeductionException("Failed to resolve `method` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/methodNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/methodNumber.h
@@ -133,7 +133,6 @@ long resolve_MethodNumber_or_throw(const MarsDict_t& mars, const ParDict_t& par,
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `method` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/model.h
+++ b/src/metkit/mars2grib/backend/deductions/model.h
@@ -129,7 +129,6 @@ std::string resolve_Model_or_throw(const MarsDict_t& mars, const ParDict_t& par,
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `model` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/model.h
+++ b/src/metkit/mars2grib/backend/deductions/model.h
@@ -55,7 +55,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -131,8 +130,6 @@ std::string resolve_Model_or_throw(const MarsDict_t& mars, const ParDict_t& par,
             Mars2GribDeductionException("Failed to resolve `model` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/numberOfForecastsInEnsemble.h
+++ b/src/metkit/mars2grib/backend/deductions/numberOfForecastsInEnsemble.h
@@ -155,7 +155,6 @@ long resolve_NumberOfForecastsInEnsemble_or_throw(const MarsDict_t& mars, const 
         std::throw_with_nested(Mars2GribDeductionException(
             "Failed to resolve `numberOfForecastsInEnsemble` from input dictionaries", Here()));
     };
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/numberOfForecastsInEnsemble.h
+++ b/src/metkit/mars2grib/backend/deductions/numberOfForecastsInEnsemble.h
@@ -44,7 +44,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/logUtils.h"
@@ -157,8 +156,6 @@ long resolve_NumberOfForecastsInEnsemble_or_throw(const MarsDict_t& mars, const 
             "Failed to resolve `numberOfForecastsInEnsemble` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/numberOfTimeRanges.h
+++ b/src/metkit/mars2grib/backend/deductions/numberOfTimeRanges.h
@@ -49,7 +49,6 @@
 
 // Details
 #include "metkit/mars2grib/backend/deductions/detail/timeUtils.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -136,30 +135,25 @@ long numberOfTimeRanges(const MarsDict_t& mars, const ParDict_t& par) {
             return numberOfTimeRanges;
         }
 
-        if (hasStatType) {
+        // Retrieve MARS stattype
+        std::string statTypeVal = get_or_throw<std::string>(mars, "stattype");
 
-            // Retrieve MARS stattype
-            std::string statTypeVal = get_or_throw<std::string>(mars, "stattype");
+        // Count number of blocks in stattype
+        long numberOfBlocks = static_cast<long>(countBlocks(statTypeVal));
 
-            // Count number of blocks in stattype
-            long numberOfBlocks = static_cast<long>(countBlocks(statTypeVal));
+        // Compute number of time ranges
+        long numberOfTimeRanges = numberOfBlocks + 1;
 
-            // Compute number of time ranges
-            long numberOfTimeRanges = numberOfBlocks + 1;
+        // Emit RESOLVE log entry
+        MARS2GRIB_LOG_RESOLVE([&]() {
+            std::string logMsg = "`numberOfTimeRanges` resolved from input dictionaries: value='";
+            logMsg += std::to_string(numberOfTimeRanges) + "'";
+            return logMsg;
+        }());
 
-            // Emit RESOLVE log entry
-            MARS2GRIB_LOG_RESOLVE([&]() {
-                std::string logMsg = "`numberOfTimeRanges` resolved from input dictionaries: value='";
-                logMsg += std::to_string(numberOfTimeRanges) + "'";
-                return logMsg;
-            }());
+        // Number of time ranges = number of blocks + 1
+        return numberOfTimeRanges;
 
-            // Number of time ranges = number of blocks + 1
-            return numberOfTimeRanges;
-        }
-
-        // Remove compiler warning
-        mars2gribUnreachable();
     }
     catch (...) {
 
@@ -167,9 +161,6 @@ long numberOfTimeRanges(const MarsDict_t& mars, const ParDict_t& par) {
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `numberOfTimeRanges` from input dictionaries", Here()));
     };
-
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/numberOfTimeRanges.h
+++ b/src/metkit/mars2grib/backend/deductions/numberOfTimeRanges.h
@@ -153,7 +153,6 @@ long numberOfTimeRanges(const MarsDict_t& mars, const ParDict_t& par) {
 
         // Number of time ranges = number of blocks + 1
         return numberOfTimeRanges;
-
     }
     catch (...) {
 

--- a/src/metkit/mars2grib/backend/deductions/offsetToEndOf4DvarWindow.h
+++ b/src/metkit/mars2grib/backend/deductions/offsetToEndOf4DvarWindow.h
@@ -121,7 +121,6 @@ long resolve_offsetToEndOf4DvarWindow_or_throw(const MarsDict_t& mars, const Par
         std::throw_with_nested(Mars2GribDeductionException(
             "Failed to resolve `offsetToEndOf4DvarWindow` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/offsetToEndOf4DvarWindow.h
+++ b/src/metkit/mars2grib/backend/deductions/offsetToEndOf4DvarWindow.h
@@ -44,7 +44,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -123,8 +122,6 @@ long resolve_offsetToEndOf4DvarWindow_or_throw(const MarsDict_t& mars, const Par
             "Failed to resolve `offsetToEndOf4DvarWindow` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/paramId.h
+++ b/src/metkit/mars2grib/backend/deductions/paramId.h
@@ -46,7 +46,6 @@
 
 // exception and logging
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/backend/deductions/periodItMax.h
+++ b/src/metkit/mars2grib/backend/deductions/periodItMax.h
@@ -52,7 +52,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -143,8 +142,6 @@ std::optional<long> resolve_PeriodItMax_opt(const MarsDict_t& mars, const ParDic
             Mars2GribDeductionException("Failed to resolve `iTmax` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/periodItMax.h
+++ b/src/metkit/mars2grib/backend/deductions/periodItMax.h
@@ -141,7 +141,6 @@ std::optional<long> resolve_PeriodItMax_opt(const MarsDict_t& mars, const ParDic
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `iTmax` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/periodItMin.h
+++ b/src/metkit/mars2grib/backend/deductions/periodItMin.h
@@ -52,7 +52,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -141,8 +140,6 @@ std::optional<long> resolve_PeriodItMin_opt(const MarsDict_t& mars, const ParDic
             Mars2GribDeductionException("Failed to resolve `iTmin` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/periodItMin.h
+++ b/src/metkit/mars2grib/backend/deductions/periodItMin.h
@@ -139,7 +139,6 @@ std::optional<long> resolve_PeriodItMin_opt(const MarsDict_t& mars, const ParDic
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `iTmin` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/perturbationNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/perturbationNumber.h
@@ -144,7 +144,6 @@ long resolve_PerturbationNumber_or_throw(const MarsDict_t& mars, const ParDict_t
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `number` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/perturbationNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/perturbationNumber.h
@@ -67,7 +67,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -146,8 +145,6 @@ long resolve_PerturbationNumber_or_throw(const MarsDict_t& mars, const ParDict_t
             Mars2GribDeductionException("Failed to resolve `number` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/productionStatusOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/deductions/productionStatusOfProcessedData.h
@@ -49,7 +49,6 @@
 
 // Table includes
 #include "metkit/mars2grib/backend/tables/productionStatusOfProcessedData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -168,8 +167,6 @@ tables::ProductionStatusOfProcessedData resolve_ProductionStatusOfProcessedData_
             "Failed to resolve `productionStatusOfProcessedData` from input dictionaries", Here()));
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/productionStatusOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/deductions/productionStatusOfProcessedData.h
@@ -166,7 +166,6 @@ tables::ProductionStatusOfProcessedData resolve_ProductionStatusOfProcessedData_
         std::throw_with_nested(Mars2GribDeductionException(
             "Failed to resolve `productionStatusOfProcessedData` from input dictionaries", Here()));
     }
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/pvArray.h
+++ b/src/metkit/mars2grib/backend/deductions/pvArray.h
@@ -76,7 +76,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -281,8 +280,6 @@ inline bool hostIsLittleEndian_or_throw() {
 
     throw Mars2GribDeductionException("Unsupported floating-point representation (non IEEE754 double?)", Here());
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 ///
@@ -400,8 +397,6 @@ std::vector<double> lookup_PvArrayFromSize_or_throw(long pvArraySize) {
         std::throw_with_nested(Mars2GribDeductionException("Unable to lookup PV array from size", Here()));
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 ///
@@ -651,8 +646,6 @@ std::vector<double> resolve_PvArray_or_throw(const MarsDict_t& mars, const ParDi
             Mars2GribDeductionException("Failed to resolve `pvArray` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/pvArray.h
+++ b/src/metkit/mars2grib/backend/deductions/pvArray.h
@@ -279,7 +279,6 @@ inline bool hostIsLittleEndian_or_throw() {
         return true;  // host LE
 
     throw Mars2GribDeductionException("Unsupported floating-point representation (non IEEE754 double?)", Here());
-
 }
 
 ///
@@ -396,7 +395,6 @@ std::vector<double> lookup_PvArrayFromSize_or_throw(long pvArraySize) {
     catch (...) {
         std::throw_with_nested(Mars2GribDeductionException("Unable to lookup PV array from size", Here()));
     }
-
 }
 
 ///
@@ -645,7 +643,6 @@ std::vector<double> resolve_PvArray_or_throw(const MarsDict_t& mars, const ParDi
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `pvArray` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/realization.h
+++ b/src/metkit/mars2grib/backend/deductions/realization.h
@@ -142,7 +142,6 @@ long resolve_Realization_or_throw(const MarsDict_t& mars, const ParDict_t& par, 
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `realization` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/realization.h
+++ b/src/metkit/mars2grib/backend/deductions/realization.h
@@ -58,7 +58,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -144,8 +143,6 @@ long resolve_Realization_or_throw(const MarsDict_t& mars, const ParDict_t& par, 
             Mars2GribDeductionException("Failed to resolve `realization` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/referenceDateTime.h
+++ b/src/metkit/mars2grib/backend/deductions/referenceDateTime.h
@@ -112,7 +112,6 @@ eckit::DateTime resolve_ReferenceDateTime_or_throw(const MarsDict_t& mars, const
         std::throw_with_nested(Mars2GribDeductionException(
             "Unable to get `date` and `time` from Mars dictionary to deduce `dateTime`", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/referenceDateTime.h
+++ b/src/metkit/mars2grib/backend/deductions/referenceDateTime.h
@@ -15,7 +15,6 @@
 #include "eckit/types/Date.h"
 #include "eckit/types/DateTime.h"
 #include "eckit/types/Time.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/mars2grib/backend/deductions/detail/timeUtils.h"
 
@@ -114,8 +113,6 @@ eckit::DateTime resolve_ReferenceDateTime_or_throw(const MarsDict_t& mars, const
             "Unable to get `date` and `time` from Mars dictionary to deduce `dateTime`", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/resolution.h
+++ b/src/metkit/mars2grib/backend/deductions/resolution.h
@@ -131,7 +131,6 @@ std::string resolve_Resolution_or_throw(const MarsDict_t& mars, const ParDict_t&
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `resolution` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/resolution.h
+++ b/src/metkit/mars2grib/backend/deductions/resolution.h
@@ -54,7 +54,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -133,8 +132,6 @@ std::string resolve_Resolution_or_throw(const MarsDict_t& mars, const ParDict_t&
             Mars2GribDeductionException("Failed to resolve `resolution` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/satelliteNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/satelliteNumber.h
@@ -52,7 +52,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -131,8 +130,6 @@ long resolve_satelliteNumber_or_throw(const MarsDict_t& mars, const ParDict_t& p
             Mars2GribDeductionException("Failed to resolve `satelliteNumber` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/satelliteNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/satelliteNumber.h
@@ -129,7 +129,6 @@ long resolve_satelliteNumber_or_throw(const MarsDict_t& mars, const ParDict_t& p
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `satelliteNumber` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/satelliteSeries.h
+++ b/src/metkit/mars2grib/backend/deductions/satelliteSeries.h
@@ -52,7 +52,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -130,8 +129,6 @@ long resolve_SatelliteSeries_or_throw(const MarsDict_t& mars, const ParDict_t& p
             Mars2GribDeductionException("Failed to resolve `satelliteSeries` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/satelliteSeries.h
+++ b/src/metkit/mars2grib/backend/deductions/satelliteSeries.h
@@ -128,7 +128,6 @@ long resolve_SatelliteSeries_or_throw(const MarsDict_t& mars, const ParDict_t& p
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `satelliteSeries` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/scaleFactorOfCentralWaveNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/scaleFactorOfCentralWaveNumber.h
@@ -46,7 +46,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -127,8 +126,6 @@ long resolve_ScaleFactorOfCentralWaveNumber_or_throw(const MarsDict_t& mars, con
             "Failed to resolve `scaleFactorOfCentralWaveNumber` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/scaleFactorOfCentralWaveNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/scaleFactorOfCentralWaveNumber.h
@@ -125,7 +125,6 @@ long resolve_ScaleFactorOfCentralWaveNumber_or_throw(const MarsDict_t& mars, con
         std::throw_with_nested(Mars2GribDeductionException(
             "Failed to resolve `scaleFactorOfCentralWaveNumber` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/scaledValueOfCentralWaveNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/scaledValueOfCentralWaveNumber.h
@@ -47,7 +47,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -128,8 +127,6 @@ long resolve_ScaledValueOfCentralWaveNumber_or_throw(const MarsDict_t& mars, con
             "Failed to resolve `scaledValueOfCentralWaveNumber` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/scaledValueOfCentralWaveNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/scaledValueOfCentralWaveNumber.h
@@ -126,7 +126,6 @@ long resolve_ScaledValueOfCentralWaveNumber_or_throw(const MarsDict_t& mars, con
         std::throw_with_nested(Mars2GribDeductionException(
             "Failed to resolve `scaledValueOfCentralWaveNumber` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/shapeOfTheEarth.h
+++ b/src/metkit/mars2grib/backend/deductions/shapeOfTheEarth.h
@@ -51,7 +51,6 @@
 
 // Tables
 #include "metkit/mars2grib/backend/tables/shapeOfTheReferenceSystem.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"

--- a/src/metkit/mars2grib/backend/deductions/significanceOfReferenceTime.h
+++ b/src/metkit/mars2grib/backend/deductions/significanceOfReferenceTime.h
@@ -161,7 +161,6 @@ tables::SignificanceOfReferenceTime resolve_SignificanceOfReferenceTime_or_throw
         std::throw_with_nested(Mars2GribDeductionException(
             "Failed to resolve `significanceOfReferenceTime` from input dictionaries", Here()));
     }
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/significanceOfReferenceTime.h
+++ b/src/metkit/mars2grib/backend/deductions/significanceOfReferenceTime.h
@@ -54,7 +54,6 @@
 
 // Tables includes
 #include "metkit/mars2grib/backend/tables/significanceOfReferenceTime.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -163,8 +162,6 @@ tables::SignificanceOfReferenceTime resolve_SignificanceOfReferenceTime_or_throw
             "Failed to resolve `significanceOfReferenceTime` from input dictionaries", Here()));
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/statisticsDescriptor.h
+++ b/src/metkit/mars2grib/backend/deductions/statisticsDescriptor.h
@@ -9,7 +9,6 @@
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Deductions
 #include "metkit/mars2grib/backend/deductions/forecastTimeInSeconds.h"
@@ -167,17 +166,16 @@ inline StatisticalProcessing getTimeDescriptorFromMars_orThrow(
                 }
             }
 
-            return out;
+            break;  // TODO: Support multi-loop statistics
         }
+
+        return out;
     }
     catch (...) {
         // Rethrow nested exceptions
         std::throw_with_nested(
             Mars2GribDeductionException("Unable to compute statistics descriptor from Mars dictionary", Here()));
     };
-
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/stream.h
+++ b/src/metkit/mars2grib/backend/deductions/stream.h
@@ -53,7 +53,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -118,8 +117,6 @@ std::string resolve_Stream_or_throw(const MarsDict_t& mars, const ParDict_t& par
             Mars2GribDeductionException("Failed to resolve `stream` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/stream.h
+++ b/src/metkit/mars2grib/backend/deductions/stream.h
@@ -116,7 +116,6 @@ std::string resolve_Stream_or_throw(const MarsDict_t& mars, const ParDict_t& par
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `stream` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/subCentre.h
+++ b/src/metkit/mars2grib/backend/deductions/subCentre.h
@@ -52,7 +52,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/backend/deductions/subSetTrunc.h
+++ b/src/metkit/mars2grib/backend/deductions/subSetTrunc.h
@@ -153,7 +153,6 @@ long resolve_SubSetTruncation_or_throw(const MarsDict_t& mars, const ParDict_t& 
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `subSetTruncation` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/subSetTrunc.h
+++ b/src/metkit/mars2grib/backend/deductions/subSetTrunc.h
@@ -49,7 +49,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -155,8 +154,6 @@ long resolve_SubSetTruncation_or_throw(const MarsDict_t& mars, const ParDict_t& 
             Mars2GribDeductionException("Failed to resolve `subSetTruncation` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/systemNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/systemNumber.h
@@ -50,7 +50,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -112,8 +111,6 @@ long resolve_SystemNumber_or_throw(const MarsDict_t& mars, const ParDict_t& par,
             Mars2GribDeductionException("Failed to resolve `systemNumber` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/systemNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/systemNumber.h
@@ -110,7 +110,6 @@ long resolve_SystemNumber_or_throw(const MarsDict_t& mars, const ParDict_t& par,
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `systemNumber` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/tablesVersion.h
+++ b/src/metkit/mars2grib/backend/deductions/tablesVersion.h
@@ -53,7 +53,6 @@
 // Core deduction includes
 #include "metkit/codes/api/CodesAPI.h"
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/backend/deductions/timeIncrementInSeconds.h
+++ b/src/metkit/mars2grib/backend/deductions/timeIncrementInSeconds.h
@@ -44,7 +44,6 @@ std::optional<long> timeIncrementInSeconds_opt(const MarsDict_t& mars, const Par
         std::throw_with_nested(
             Mars2GribDeductionException("Unable to get `timeIncrementInSeconds` from Mars dictionary", Here()));
     };
-
 };
 
 
@@ -70,7 +69,6 @@ long timeIncrementInSeconds_or_throw(const MarsDict_t& mars, const ParDict_t& pa
         std::throw_with_nested(
             Mars2GribDeductionException("Unable to get `timeIncrementInSeconds` from Mars dictionary", Here()));
     };
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/timeIncrementInSeconds.h
+++ b/src/metkit/mars2grib/backend/deductions/timeIncrementInSeconds.h
@@ -9,7 +9,6 @@
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/config/LibMetkit.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
@@ -46,8 +45,6 @@ std::optional<long> timeIncrementInSeconds_opt(const MarsDict_t& mars, const Par
             Mars2GribDeductionException("Unable to get `timeIncrementInSeconds` from Mars dictionary", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 
@@ -74,8 +71,6 @@ long timeIncrementInSeconds_or_throw(const MarsDict_t& mars, const ParDict_t& pa
             Mars2GribDeductionException("Unable to get `timeIncrementInSeconds` from Mars dictionary", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/timeSpanInSeconds.h
+++ b/src/metkit/mars2grib/backend/deductions/timeSpanInSeconds.h
@@ -101,7 +101,6 @@ long resolve_TimeSpanInSeconds_or_throw(const MarsDict_t& mars, const ParDict_t&
         // Rethrow nested exceptions
         std::throw_with_nested(Mars2GribDeductionException("Unable to get `timespan` from Mars dictionary", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/timeSpanInSeconds.h
+++ b/src/metkit/mars2grib/backend/deductions/timeSpanInSeconds.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Exceptions
 #include "metkit/config/LibMetkit.h"
@@ -103,8 +102,6 @@ long resolve_TimeSpanInSeconds_or_throw(const MarsDict_t& mars, const ParDict_t&
         std::throw_with_nested(Mars2GribDeductionException("Unable to get `timespan` from Mars dictionary", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/type.h
+++ b/src/metkit/mars2grib/backend/deductions/type.h
@@ -53,7 +53,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -114,8 +113,6 @@ std::string resolve_Type_or_throw(const MarsDict_t& mars, const ParDict_t& par, 
         std::throw_with_nested(Mars2GribDeductionException("Failed to resolve `type` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/type.h
+++ b/src/metkit/mars2grib/backend/deductions/type.h
@@ -112,7 +112,6 @@ std::string resolve_Type_or_throw(const MarsDict_t& mars, const ParDict_t& par, 
         // Rethrow nested exceptions
         std::throw_with_nested(Mars2GribDeductionException("Failed to resolve `type` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/typeOfEnsembleForecast.h
+++ b/src/metkit/mars2grib/backend/deductions/typeOfEnsembleForecast.h
@@ -53,7 +53,6 @@
 
 // Tables includes
 #include "metkit/mars2grib/backend/tables/typeOfEnsembleForecast.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -163,8 +162,6 @@ tables::TypeOfEnsembleForecast resolve_TypeOfEnsembleForecast_or_throw(const Mar
             Mars2GribDeductionException("Failed to resolve `typeOfEnsembleForecast` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/typeOfEnsembleForecast.h
+++ b/src/metkit/mars2grib/backend/deductions/typeOfEnsembleForecast.h
@@ -161,7 +161,6 @@ tables::TypeOfEnsembleForecast resolve_TypeOfEnsembleForecast_or_throw(const Mar
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `typeOfEnsembleForecast` from input dictionaries", Here()));
     };
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/typeOfGeneratingProcess.h
+++ b/src/metkit/mars2grib/backend/deductions/typeOfGeneratingProcess.h
@@ -173,7 +173,6 @@ std::optional<tables::TypeOfGeneratingProcess> resolve_TypeOfGeneratingProcess_o
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `typeOfGeneratingProcess` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/typeOfGeneratingProcess.h
+++ b/src/metkit/mars2grib/backend/deductions/typeOfGeneratingProcess.h
@@ -53,7 +53,6 @@
 
 // Tables includes
 #include "metkit/mars2grib/backend/tables/typeOfGeneratingProcess.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
@@ -175,8 +174,6 @@ std::optional<tables::TypeOfGeneratingProcess> resolve_TypeOfGeneratingProcess_o
             Mars2GribDeductionException("Failed to resolve `typeOfGeneratingProcess` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/typeOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/deductions/typeOfProcessedData.h
@@ -51,7 +51,6 @@
 
 // Tables includes
 #include "metkit/mars2grib/backend/tables/typeOfProcessedData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"

--- a/src/metkit/mars2grib/backend/deductions/waveDirectionGrid.h
+++ b/src/metkit/mars2grib/backend/deductions/waveDirectionGrid.h
@@ -378,7 +378,6 @@ WaveDirectionGrid resolve_WaveDirectionGrid_or_throw(const MarsDict_t& mars, con
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `waveDirectionGrid` from input dictionaries", Here()));
     };
-
 }
 
 

--- a/src/metkit/mars2grib/backend/deductions/waveDirectionGrid.h
+++ b/src/metkit/mars2grib/backend/deductions/waveDirectionGrid.h
@@ -61,7 +61,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -380,8 +379,6 @@ WaveDirectionGrid resolve_WaveDirectionGrid_or_throw(const MarsDict_t& mars, con
             Mars2GribDeductionException("Failed to resolve `waveDirectionGrid` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 

--- a/src/metkit/mars2grib/backend/deductions/waveDirectionNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/waveDirectionNumber.h
@@ -112,7 +112,6 @@ long resolve_WaveDirectionNumber_or_throw(const MarsDict_t& mars, const ParDict_
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `waveDirectionNumber` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/waveDirectionNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/waveDirectionNumber.h
@@ -54,7 +54,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -114,8 +113,6 @@ long resolve_WaveDirectionNumber_or_throw(const MarsDict_t& mars, const ParDict_
             Mars2GribDeductionException("Failed to resolve `waveDirectionNumber` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/waveFrequencyGrid.h
+++ b/src/metkit/mars2grib/backend/deductions/waveFrequencyGrid.h
@@ -389,7 +389,6 @@ WaveFrequencyGrid resolve_WaveFrequencyGrid_or_throw(const MarsDict_t& mars, con
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `waveFrequencyGrid` from input dictionaries", Here()));
     };
-
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/waveFrequencyGrid.h
+++ b/src/metkit/mars2grib/backend/deductions/waveFrequencyGrid.h
@@ -57,7 +57,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -391,8 +390,6 @@ WaveFrequencyGrid resolve_WaveFrequencyGrid_or_throw(const MarsDict_t& mars, con
             Mars2GribDeductionException("Failed to resolve `waveFrequencyGrid` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 

--- a/src/metkit/mars2grib/backend/deductions/waveFrequencyNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/waveFrequencyNumber.h
@@ -112,7 +112,6 @@ long resolve_WaveFrequencyNumber_or_throw(const MarsDict_t& mars, const ParDict_
         std::throw_with_nested(
             Mars2GribDeductionException("Failed to resolve `waveFrequencyNumber` from input dictionaries", Here()));
     };
-
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/deductions/waveFrequencyNumber.h
+++ b/src/metkit/mars2grib/backend/deductions/waveFrequencyNumber.h
@@ -54,7 +54,6 @@
 
 // Core deduction includes
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/logUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
@@ -114,8 +113,6 @@ long resolve_WaveFrequencyNumber_or_throw(const MarsDict_t& mars, const ParDict_
             Mars2GribDeductionException("Failed to resolve `waveFrequencyNumber` from input dictionaries", Here()));
     };
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 };
 
 }  // namespace metkit::mars2grib::backend::deductions

--- a/src/metkit/mars2grib/backend/encodeValues.h
+++ b/src/metkit/mars2grib/backend/encodeValues.h
@@ -39,7 +39,6 @@
 
 // Project includes
 #include "metkit/codes/api/CodesTypes.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend {

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer0.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer0.h
@@ -36,7 +36,6 @@
 #pragma once
 
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
 

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer1.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer1.h
@@ -36,7 +36,6 @@
 #pragma once
 
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
 

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer2.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer2.h
@@ -36,7 +36,6 @@
 #pragma once
 
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
 
@@ -116,8 +115,6 @@ void allocateTemplateNumber2(const MarsDict_t& mars, const ParDict_t& par, const
     catch (...) {
         std::throw_with_nested(Mars2GribGenericException("Error preparing section 2 with template number", Here()));
     }
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::sections::initializers

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer3.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer3.h
@@ -38,7 +38,6 @@
 #include <vector>
 
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
@@ -116,8 +115,6 @@ void allocateTemplateNumber3(const MarsDict_t& mars, const ParDict_t& par, const
     catch (...) {
         std::throw_with_nested(Mars2GribGenericException("Error preparing section 3 with template number", Here()));
     }
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::sections::initializers

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer4.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer4.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
@@ -77,8 +76,6 @@ void allocateTemplateNumber4(const MarsDict_t& mars, const ParDict_t& par, const
     catch (...) {
         std::throw_with_nested(Mars2GribGenericException("Error preparing section 4 with template number", Here()));
     }
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::sections::initializers

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer5.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializer5.h
@@ -30,7 +30,6 @@
 #pragma once
 
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
@@ -77,8 +76,6 @@ void allocateTemplateNumber5(const MarsDict_t& mars, const ParDict_t& par, const
     catch (...) {
         std::throw_with_nested(Mars2GribGenericException("Error preparing section 5 with template number", Here()));
     }
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 }  // namespace metkit::mars2grib::backend::sections::initializers

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h
@@ -38,7 +38,6 @@
 #include <utility>
 
 #include "metkit/mars2grib/backend/concepts/EncodingCallbacksRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::initializers {
 

--- a/src/metkit/mars2grib/backend/sections/initializers/sectionRegistry.h
+++ b/src/metkit/mars2grib/backend/sections/initializers/sectionRegistry.h
@@ -44,7 +44,6 @@
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializer4.h"
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializer5.h"
 #include "metkit/mars2grib/backend/sections/initializers/sectionInitializerCore.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/backend/sections/resolver/ActiveConceptsData.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/ActiveConceptsData.h
@@ -40,7 +40,6 @@
 
 // Project includes
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::resolver {
 

--- a/src/metkit/mars2grib/backend/sections/resolver/CompressionMask.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/CompressionMask.h
@@ -145,7 +145,6 @@
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/sections/resolver/ResolvedTemplateData.h"
 #include "metkit/mars2grib/backend/sections/resolver/TemplateSignatureKey.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::resolver::detail {

--- a/src/metkit/mars2grib/backend/sections/resolver/Recipe.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/Recipe.h
@@ -53,7 +53,6 @@
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/sections/resolver/ResolvedTemplateData.h"
 #include "metkit/mars2grib/backend/sections/resolver/Select.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::backend::sections::resolver::dsl {

--- a/src/metkit/mars2grib/backend/sections/resolver/Recipes.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/Recipes.h
@@ -47,7 +47,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/sections/resolver/Recipe.h"
 #include "metkit/mars2grib/backend/sections/resolver/ResolvedTemplateData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::resolver::dsl {
 

--- a/src/metkit/mars2grib/backend/sections/resolver/ResolvedTemplateData.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/ResolvedTemplateData.h
@@ -49,7 +49,6 @@
 
 // Project includes
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::resolver::dsl {
 

--- a/src/metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h
@@ -149,8 +149,6 @@ inline SectionLayoutData make_SectionLayoutData_or_throw(std::size_t sectionNumb
     catch (...) {
         std::throw_with_nested(Mars2GribGenericException("Unable to create SectionLayoutData", Here()));
     }
-
-
 }
 
 }  // namespace detail

--- a/src/metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h
@@ -40,7 +40,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/sections/resolver/ResolvedTemplateData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::resolver {
@@ -151,7 +150,7 @@ inline SectionLayoutData make_SectionLayoutData_or_throw(std::size_t sectionNumb
         std::throw_with_nested(Mars2GribGenericException("Unable to create SectionLayoutData", Here()));
     }
 
-    mars2gribUnreachable();
+
 }
 
 }  // namespace detail

--- a/src/metkit/mars2grib/backend/sections/resolver/SectionTemplateSelector.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/SectionTemplateSelector.h
@@ -44,7 +44,6 @@
 #include "metkit/mars2grib/backend/sections/resolver/Recipes.h"
 #include "metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h"
 #include "metkit/mars2grib/backend/sections/resolver/TemplateSignatureKey.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::resolver {

--- a/src/metkit/mars2grib/backend/sections/resolver/Select.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/Select.h
@@ -48,7 +48,6 @@
 
 // Project includes
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::sections::resolver::dsl {
@@ -136,9 +135,6 @@ private:
         else {
             return GeneralRegistry::make_id_array_from_variants<Concept, Vs...>();
         }
-
-        // Remove compiler warning
-        mars2gribUnreachable();
     }
 
 public:

--- a/src/metkit/mars2grib/backend/sections/resolver/Select.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/Select.h
@@ -135,6 +135,10 @@ private:
         else {
             return GeneralRegistry::make_id_array_from_variants<Concept, Vs...>();
         }
+
+        #if defined(__INTEL_COMPILER)
+        __builtin_unreachable();
+        #endif
     }
 
 public:

--- a/src/metkit/mars2grib/backend/sections/resolver/Select.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/Select.h
@@ -136,9 +136,9 @@ private:
             return GeneralRegistry::make_id_array_from_variants<Concept, Vs...>();
         }
 
-        #if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER)
         __builtin_unreachable();
-        #endif
+#endif
     }
 
 public:

--- a/src/metkit/mars2grib/backend/sections/resolver/TemplateSignatureKey.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/TemplateSignatureKey.h
@@ -46,7 +46,6 @@
 
 // Project includes
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::backend::sections::resolver::detail {
 

--- a/src/metkit/mars2grib/backend/sections/resolver/dsl.h
+++ b/src/metkit/mars2grib/backend/sections/resolver/dsl.h
@@ -3,4 +3,3 @@
 #include "metkit/mars2grib/backend/sections/resolver/Recipe.h"
 #include "metkit/mars2grib/backend/sections/resolver/Recipes.h"
 #include "metkit/mars2grib/backend/sections/resolver/Select.h"
-#include "metkit/mars2grib/utils/generalUtils.h"

--- a/src/metkit/mars2grib/backend/tables/backgroundProcess.h
+++ b/src/metkit/mars2grib/backend/tables/backgroundProcess.h
@@ -241,7 +241,6 @@ inline std::string enum2name_BackgroundProcess_or_throw(BackgroundProcess value)
             errMsg += std::to_string(static_cast<long>(value));
             throw Mars2GribTableException(errMsg, Here());
     }
-
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/backgroundProcess.h
+++ b/src/metkit/mars2grib/backend/tables/backgroundProcess.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {
@@ -158,8 +157,6 @@ inline BackgroundProcess name2enum_BackgroundProcess_or_throw(const std::string&
             "'aifs-compo-single-mse', 'aifs-compo-ens-crps'}";
         throw Mars2GribTableException(errMsg, Here());
     }
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 ///
@@ -245,8 +242,6 @@ inline std::string enum2name_BackgroundProcess_or_throw(BackgroundProcess value)
             throw Mars2GribTableException(errMsg, Here());
     }
 
-    // Remove compiler warning
-    mars2gribUnreachable();
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/derivedForecast.h
+++ b/src/metkit/mars2grib/backend/tables/derivedForecast.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {

--- a/src/metkit/mars2grib/backend/tables/productionStatusOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/tables/productionStatusOfProcessedData.h
@@ -106,8 +106,6 @@ inline std::string enum2name_ProductionStatusOfProcessedData_or_throw(Production
         default:
             throw Mars2GribTableException("Invalid ProductionStatusOfProcessedData enum value", Here());
     }
-
-
 }
 
 ///
@@ -156,8 +154,6 @@ inline ProductionStatusOfProcessedData name2enum_ProductionStatusOfProcessedData
         return ProductionStatusOfProcessedData::Missing;
 
     throw Mars2GribTableException("Invalid ProductionStatusOfProcessedData name: '" + name + "'", Here());
-
-
 }
 
 ///
@@ -209,8 +205,6 @@ inline ProductionStatusOfProcessedData long2enum_ProductionStatusOfProcessedData
             throw Mars2GribTableException(
                 "Invalid ProductionStatusOfProcessedData numeric value: " + std::to_string(value), Here());
     }
-
-
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/productionStatusOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/tables/productionStatusOfProcessedData.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {
@@ -108,7 +107,7 @@ inline std::string enum2name_ProductionStatusOfProcessedData_or_throw(Production
             throw Mars2GribTableException("Invalid ProductionStatusOfProcessedData enum value", Here());
     }
 
-    mars2gribUnreachable();
+
 }
 
 ///
@@ -158,7 +157,7 @@ inline ProductionStatusOfProcessedData name2enum_ProductionStatusOfProcessedData
 
     throw Mars2GribTableException("Invalid ProductionStatusOfProcessedData name: '" + name + "'", Here());
 
-    mars2gribUnreachable();
+
 }
 
 ///
@@ -211,7 +210,7 @@ inline ProductionStatusOfProcessedData long2enum_ProductionStatusOfProcessedData
                 "Invalid ProductionStatusOfProcessedData numeric value: " + std::to_string(value), Here());
     }
 
-    mars2gribUnreachable();
+
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/shapeOfTheReferenceSystem.h
+++ b/src/metkit/mars2grib/backend/tables/shapeOfTheReferenceSystem.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {

--- a/src/metkit/mars2grib/backend/tables/significanceOfReferenceTime.h
+++ b/src/metkit/mars2grib/backend/tables/significanceOfReferenceTime.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 
@@ -120,7 +119,7 @@ inline SignificanceOfReferenceTime name2enum_SignificanceOfReferenceTime_or_thro
         throw Mars2GribTableException(errMsg, Here());
     }
 
-    mars2gribUnreachable();
+
 }
 
 ///
@@ -172,7 +171,7 @@ inline std::string enum2name_SignificanceOfReferenceTime_or_throw(SignificanceOf
         }
     }
 
-    mars2gribUnreachable();
+
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/significanceOfReferenceTime.h
+++ b/src/metkit/mars2grib/backend/tables/significanceOfReferenceTime.h
@@ -118,8 +118,6 @@ inline SignificanceOfReferenceTime name2enum_SignificanceOfReferenceTime_or_thro
         errMsg += "actual='" + value + "'";
         throw Mars2GribTableException(errMsg, Here());
     }
-
-
 }
 
 ///
@@ -170,8 +168,6 @@ inline std::string enum2name_SignificanceOfReferenceTime_or_throw(SignificanceOf
             throw Mars2GribTableException(errMsg, Here());
         }
     }
-
-
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/timeUnits.h
+++ b/src/metkit/mars2grib/backend/tables/timeUnits.h
@@ -126,8 +126,6 @@ inline TimeUnit name2enum_TimeUnit_or_throw(const std::string& name) {
                       "', expected={minute,hour,day,month,year,decade,normal,century,"
                       "3h,6h,12h,second,missing}";
     throw Mars2GribTableException(err, Here());
-
-
 }
 
 ///
@@ -184,8 +182,6 @@ inline std::string enum2name_TimeUnit_or_throw(TimeUnit value) {
 
     std::string err = "Invalid TimeUnit enum value: actual='" + std::to_string(static_cast<long>(value)) + "'";
     throw Mars2GribTableException(err, Here());
-
-
 }
 
 }  // namespace metkit::mars2grib::backend::tables

--- a/src/metkit/mars2grib/backend/tables/timeUnits.h
+++ b/src/metkit/mars2grib/backend/tables/timeUnits.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 
@@ -128,7 +127,7 @@ inline TimeUnit name2enum_TimeUnit_or_throw(const std::string& name) {
                       "3h,6h,12h,second,missing}";
     throw Mars2GribTableException(err, Here());
 
-    mars2gribUnreachable();
+
 }
 
 ///
@@ -186,7 +185,7 @@ inline std::string enum2name_TimeUnit_or_throw(TimeUnit value) {
     std::string err = "Invalid TimeUnit enum value: actual='" + std::to_string(static_cast<long>(value)) + "'";
     throw Mars2GribTableException(err, Here());
 
-    mars2gribUnreachable();
+
 }
 
 }  // namespace metkit::mars2grib::backend::tables

--- a/src/metkit/mars2grib/backend/tables/typeOfEnsembleForecast.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfEnsembleForecast.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {

--- a/src/metkit/mars2grib/backend/tables/typeOfGeneratingProcess.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfGeneratingProcess.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {
@@ -148,7 +147,7 @@ inline TypeOfGeneratingProcess name2enum_TypeOfGeneratingProcess_or_throw(const 
         throw Mars2GribTableException(errMsg, Here());
     }
 
-    mars2gribUnreachable();
+
 }
 
 ///
@@ -232,7 +231,7 @@ inline std::string enum2name_TypeOfGeneratingProcess_or_throw(TypeOfGeneratingPr
             throw Mars2GribTableException(errMsg, Here());
     }
 
-    mars2gribUnreachable();
+
 }
 
 }  // namespace metkit::mars2grib::backend::tables

--- a/src/metkit/mars2grib/backend/tables/typeOfGeneratingProcess.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfGeneratingProcess.h
@@ -146,8 +146,6 @@ inline TypeOfGeneratingProcess name2enum_TypeOfGeneratingProcess_or_throw(const 
         errMsg += "actual='" + value + "'";
         throw Mars2GribTableException(errMsg, Here());
     }
-
-
 }
 
 ///
@@ -230,8 +228,6 @@ inline std::string enum2name_TypeOfGeneratingProcess_or_throw(TypeOfGeneratingPr
             errMsg += std::to_string(static_cast<long>(value));
             throw Mars2GribTableException(errMsg, Here());
     }
-
-
 }
 
 }  // namespace metkit::mars2grib::backend::tables

--- a/src/metkit/mars2grib/backend/tables/typeOfInterval.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfInterval.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {

--- a/src/metkit/mars2grib/backend/tables/typeOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfProcessedData.h
@@ -112,8 +112,6 @@ inline TypeOfProcessedData name2enum_TypeOfProcessedData_or_throw(const std::str
     std::string errMsg = "Invalid TypeOfProcessedData name: ";
     errMsg += "actual='" + value + "'";
     throw Mars2GribTableException(errMsg, Here());
-
-
 }
 
 
@@ -201,8 +199,6 @@ inline TypeOfProcessedData long2enum_TypeOfProcessedData_or_throw(long value) {
             throw Mars2GribTableException("Invalid GRIB value for `typeOfProcessedData`: " + std::to_string(value),
                                           Here());
     }
-
-
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/typeOfProcessedData.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfProcessedData.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {
@@ -114,7 +113,7 @@ inline TypeOfProcessedData name2enum_TypeOfProcessedData_or_throw(const std::str
     errMsg += "actual='" + value + "'";
     throw Mars2GribTableException(errMsg, Here());
 
-    mars2gribUnreachable();
+
 }
 
 
@@ -203,7 +202,7 @@ inline TypeOfProcessedData long2enum_TypeOfProcessedData_or_throw(long value) {
                                           Here());
     }
 
-    mars2gribUnreachable();
+
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/typeOfStatisticalProcessing.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfStatisticalProcessing.h
@@ -141,8 +141,6 @@ inline TypeOfStatisticalProcessing name2enum_TypeOfStatisticalProcessing_or_thro
                       "covariance,difference_start_minus_end,ratio,standardized_anomaly,"
                       "summation,return_period,median,severity,mode,index_processing,missing}";
     throw Mars2GribTableException(err, Here());
-
-
 }
 
 ///
@@ -206,8 +204,6 @@ inline std::string enum2name_TypeOfStatisticalProcessing_or_throw(TypeOfStatisti
     std::string err =
         "Invalid TypeOfStatisticalProcessing enum value: actual='" + std::to_string(static_cast<long>(value)) + "'";
     throw Mars2GribTableException(err, Here());
-
-
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/typeOfStatisticalProcessing.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfStatisticalProcessing.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 
@@ -143,7 +142,7 @@ inline TypeOfStatisticalProcessing name2enum_TypeOfStatisticalProcessing_or_thro
                       "summation,return_period,median,severity,mode,index_processing,missing}";
     throw Mars2GribTableException(err, Here());
 
-    mars2gribUnreachable();
+
 }
 
 ///
@@ -208,7 +207,7 @@ inline std::string enum2name_TypeOfStatisticalProcessing_or_throw(TypeOfStatisti
         "Invalid TypeOfStatisticalProcessing enum value: actual='" + std::to_string(static_cast<long>(value)) + "'";
     throw Mars2GribTableException(err, Here());
 
-    mars2gribUnreachable();
+
 }
 
 

--- a/src/metkit/mars2grib/backend/tables/typeOfTimeIntervals.h
+++ b/src/metkit/mars2grib/backend/tables/typeOfTimeIntervals.h
@@ -12,7 +12,6 @@
 #include <string>
 
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::backend::tables {

--- a/src/metkit/mars2grib/frontend/GribHeaderLayoutData.h
+++ b/src/metkit/mars2grib/frontend/GribHeaderLayoutData.h
@@ -29,7 +29,6 @@
 // Project includes
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend {
 

--- a/src/metkit/mars2grib/frontend/header/EncodingPlan.h
+++ b/src/metkit/mars2grib/frontend/header/EncodingPlan.h
@@ -39,7 +39,6 @@
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/sections/initializers/sectionRegistry.h"
 #include "metkit/mars2grib/frontend/GribHeaderLayoutData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::frontend::header::detail {

--- a/src/metkit/mars2grib/frontend/header/SpecializedEncoder.h
+++ b/src/metkit/mars2grib/frontend/header/SpecializedEncoder.h
@@ -110,7 +110,6 @@
 // Project includes
 #include "metkit/mars2grib/frontend/GribHeaderLayoutData.h"
 #include "metkit/mars2grib/frontend/header/EncodingPlan.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::frontend::header {

--- a/src/metkit/mars2grib/frontend/make_HeaderLayout.h
+++ b/src/metkit/mars2grib/frontend/make_HeaderLayout.h
@@ -32,7 +32,6 @@
 #include "metkit/mars2grib/frontend/GribHeaderLayoutData.h"
 #include "metkit/mars2grib/frontend/resolution/resolveActiveConcepts.h"
 #include "metkit/mars2grib/frontend/resolution/resolveSectionsLayout.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 

--- a/src/metkit/mars2grib/frontend/normalization/normalizeMarsDict.h
+++ b/src/metkit/mars2grib/frontend/normalization/normalizeMarsDict.h
@@ -22,7 +22,6 @@
 #include "eckit/value/Value.h"
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization {
 

--- a/src/metkit/mars2grib/frontend/normalization/normalizeMiscDict.h
+++ b/src/metkit/mars2grib/frontend/normalization/normalizeMiscDict.h
@@ -23,7 +23,6 @@
 // Project includes
 #include "eckit/value/Value.h"
 #include "metkit/mars2grib/utils/enableOptions.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/SanitizationRegistry.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/SanitizationRegistry.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 #include "metkit/mars2grib/frontend/normalization/per_key/mars/All.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/All.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/All.h
@@ -35,4 +35,3 @@
 #include "metkit/mars2grib/frontend/normalization/per_key/mars/truncation.h"
 #include "metkit/mars2grib/frontend/normalization/per_key/mars/type.h"
 #include "metkit/mars2grib/frontend/normalization/per_key/mars/wavelength.h"
-#include "metkit/mars2grib/utils/generalUtils.h"

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/activity.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/activity.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/anoffset.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/anoffset.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/channel.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/channel.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/chem.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/chem.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/class.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/class.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/dataset.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/dataset.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/date.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/date.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/direction.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/direction.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/domain.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/domain.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/experiment.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/experiment.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/expver.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/expver.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/frequency.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/frequency.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/generation.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/generation.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/grid.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/grid.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/hdate.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/hdate.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/htime.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/htime.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/ident.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/ident.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/instrument.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/instrument.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/level.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/level.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/levelist.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/levelist.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/levtype.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/levtype.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/method.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/method.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/model.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/model.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/number.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/number.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/origin.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/origin.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/packing.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/packing.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/param.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/param.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/realization.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/realization.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/resolution.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/resolution.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/stattype.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/stattype.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/step.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/step.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/stream.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/stream.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/system.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/system.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/time.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/time.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/timespan.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/timespan.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/truncation.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/truncation.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/type.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/type.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/normalization/per_key/mars/wavelength.h
+++ b/src/metkit/mars2grib/frontend/normalization/per_key/mars/wavelength.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "eckit/value/Value.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::normalization::per_key {
 

--- a/src/metkit/mars2grib/frontend/resolution/resolveActiveConcepts.h
+++ b/src/metkit/mars2grib/frontend/resolution/resolveActiveConcepts.h
@@ -93,8 +93,6 @@ ActiveConceptsData resolve_ActiveConcepts_or_throw(const MarsDict_t& marsDict, c
     catch (...) {
         std::throw_with_nested(Mars2GribGenericException("Unable to match ActiveConcepts", Here()));
     }
-
-
 };
 
 

--- a/src/metkit/mars2grib/frontend/resolution/resolveActiveConcepts.h
+++ b/src/metkit/mars2grib/frontend/resolution/resolveActiveConcepts.h
@@ -22,7 +22,6 @@
 #include "metkit/mars2grib/backend/concepts/GeneralRegistry.h"
 #include "metkit/mars2grib/backend/concepts/MatchingCallbacksRegistry.h"
 #include "metkit/mars2grib/backend/sections/resolver/ActiveConceptsData.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::frontend::resolution {
@@ -95,7 +94,7 @@ ActiveConceptsData resolve_ActiveConcepts_or_throw(const MarsDict_t& marsDict, c
         std::throw_with_nested(Mars2GribGenericException("Unable to match ActiveConcepts", Here()));
     }
 
-    mars2gribUnreachable();
+
 };
 
 

--- a/src/metkit/mars2grib/frontend/resolution/resolveSectionsLayout.h
+++ b/src/metkit/mars2grib/frontend/resolution/resolveSectionsLayout.h
@@ -99,8 +99,6 @@ inline std::array<SectionLayoutData, backend::concepts_::GeneralRegistry::NSecti
         std::throw_with_nested(
             Mars2GribGenericException("Critical failure: Unable to resolve GRIB HeaderLayout", Here()));
     }
-
-
 }
 
 ///

--- a/src/metkit/mars2grib/frontend/resolution/resolveSectionsLayout.h
+++ b/src/metkit/mars2grib/frontend/resolution/resolveSectionsLayout.h
@@ -31,7 +31,6 @@
 #include "metkit/mars2grib/backend/sections/resolver/SectionLayoutData.h"
 #include "metkit/mars2grib/frontend/GribHeaderLayoutData.h"
 #include "metkit/mars2grib/frontend/resolution/section-recipes/SectionTemplateSelectors.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
 
 namespace metkit::mars2grib::frontend::resolution {
@@ -101,7 +100,7 @@ inline std::array<SectionLayoutData, backend::concepts_::GeneralRegistry::NSecti
             Mars2GribGenericException("Critical failure: Unable to resolve GRIB HeaderLayout", Here()));
     }
 
-    mars2gribUnreachable();
+
 }
 
 ///

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/SectionTemplateSelectors.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/SectionTemplateSelectors.h
@@ -9,7 +9,6 @@
 #include "metkit/mars2grib/frontend/resolution/section-recipes/impl/section3Recipes.h"
 #include "metkit/mars2grib/frontend/resolution/section-recipes/impl/section4Recipes.h"
 #include "metkit/mars2grib/frontend/resolution/section-recipes/impl/section5Recipes.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes {
 

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section0Recipes.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section0Recipes.h
@@ -6,7 +6,6 @@
 
 // All elements needed to used the "dsl" objects to define recipes
 #include "metkit/mars2grib/backend/sections/resolver/dsl.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes::impl {
 

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section1Recipes.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section1Recipes.h
@@ -6,7 +6,6 @@
 
 // All elements needed to used the "dsl" objects to define recipes
 #include "metkit/mars2grib/backend/sections/resolver/dsl.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes::impl {
 

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section2Recipes.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section2Recipes.h
@@ -6,7 +6,6 @@
 
 // All elements needed to used the "dsl" objects to define recipes
 #include "metkit/mars2grib/backend/sections/resolver/dsl.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes::impl {
 

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section3Recipes.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section3Recipes.h
@@ -6,7 +6,6 @@
 
 // All elements needed to used the "dsl" objects to define recipes
 #include "metkit/mars2grib/backend/sections/resolver/dsl.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes::impl {
 

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section4Recipes.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section4Recipes.h
@@ -4,7 +4,6 @@
 
 // All elements needed to used the "dsl" objects to define recipes
 #include "metkit/mars2grib/backend/sections/resolver/dsl.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes::impl {
 

--- a/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section5Recipes.h
+++ b/src/metkit/mars2grib/frontend/resolution/section-recipes/impl/section5Recipes.h
@@ -6,7 +6,6 @@
 
 // All elements needed to used the "dsl" objects to define recipes
 #include "metkit/mars2grib/backend/sections/resolver/dsl.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::frontend::resolution::recipes::impl {
 

--- a/src/metkit/mars2grib/utils/configConverter.h
+++ b/src/metkit/mars2grib/utils/configConverter.h
@@ -6,7 +6,6 @@
 
 #include "eckit/config/LocalConfiguration.h"
 #include "eckit/log/Log.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 #include "metkit/mars2grib/backend/concepts/concept_registry.h"

--- a/src/metkit/mars2grib/utils/dictionary_traits/dictaccess_codes_handle.h
+++ b/src/metkit/mars2grib/utils/dictionary_traits/dictaccess_codes_handle.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "eckit/io/Buffer.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/codes/api/CodesAPI.h"
 #include "metkit/codes/api/CodesTypes.h"
@@ -64,7 +63,6 @@
                         "` from dictionary `"s + std::string(type_name<metkit::codes::CodesHandle>()) + "`",   \
                     Here()));                                                                                  \
             }                                                                                                  \
-            mars2gribUnreachable();                                                                            \
         }                                                                                                      \
     };
 
@@ -92,7 +90,6 @@
             catch (...) {                                                           \
                 return std::nullopt;                                                \
             }                                                                       \
-            mars2gribUnreachable();                                                 \
         }                                                                           \
     };
 
@@ -120,7 +117,6 @@
                         "` in dictionary `"s + std::string(type_name<metkit::codes::CodesHandle>()) + "`", \
                     Here()));                                                                              \
             }                                                                                              \
-            mars2gribUnreachable();                                                                        \
         }                                                                                                  \
     };
 
@@ -142,7 +138,6 @@
             catch (...) {                                                              \
                 return;                                                                \
             }                                                                          \
-            mars2gribUnreachable();                                                    \
         }                                                                              \
     };
 
@@ -237,7 +232,6 @@ struct DictHas<metkit::codes::CodesHandle> {
                     std::string(type_name<metkit::codes::CodesHandle>()) + "`",
                 Here()));
         }
-        mars2gribUnreachable();
     }
 };
 
@@ -258,7 +252,6 @@ struct DictMissing<metkit::codes::CodesHandle> {
                     std::string(type_name<metkit::codes::CodesHandle>()) + "`",
                 Here()));
         }
-        mars2gribUnreachable();
     }
 
     static void setMissing(metkit::codes::CodesHandle& h, std::string_view key) noexcept(false) {
@@ -272,7 +265,6 @@ struct DictMissing<metkit::codes::CodesHandle> {
                     std::string(type_name<metkit::codes::CodesHandle>()) + "`",
                 Here()));
         }
-        mars2gribUnreachable();
     }
 };
 

--- a/src/metkit/mars2grib/utils/dictionary_traits/dictaccess_eckit_configuration.h
+++ b/src/metkit/mars2grib/utils/dictionary_traits/dictaccess_eckit_configuration.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #include "metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h"
 #include "metkit/mars2grib/utils/mars2gribExceptions.h"
@@ -62,7 +61,6 @@
                         "` from dictionary type `"s + std::string(type_name<eckit::LocalConfiguration>()) + "`",       \
                     Here()));                                                                                          \
             }                                                                                                          \
-            mars2gribUnreachable();                                                                                    \
         }                                                                                                              \
     };
 
@@ -91,7 +89,6 @@
             catch (...) {                                                           \
                 return std::nullopt;                                                \
             }                                                                       \
-            mars2gribUnreachable();                                                 \
         }                                                                           \
     };
 
@@ -111,7 +108,6 @@
             }                                                                           \
             catch (...) {                                                               \
             }                                                                           \
-            mars2gribUnreachable();                                                     \
         }                                                                               \
     };
 
@@ -140,7 +136,6 @@
                         "` in dictionary type `"s + std::string(type_name<eckit::LocalConfiguration>()) + "`", \
                     Here()));                                                                                  \
             }                                                                                                  \
-            mars2gribUnreachable();                                                                            \
         }                                                                                                      \
     };
 
@@ -265,7 +260,6 @@ struct DictHas<eckit::LocalConfiguration> {
                     std::string(type_name<eckit::LocalConfiguration>()) + "`",
                 Here()));
         }
-        mars2gribUnreachable();
     }
 };
 

--- a/src/metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h
+++ b/src/metkit/mars2grib/utils/dictionary_traits/dictionary_access_traits.h
@@ -11,7 +11,6 @@
 #include <utility>
 
 #include "eckit/exception/Exceptions.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 // Exceptions
 #include "metkit/config/LibMetkit.h"
@@ -55,7 +54,7 @@ struct DictHas {
 
     static bool has(const Dict&, std::string_view) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictHas not specialized for this Dict");
-        mars2gribUnreachable();
+        return false;  // Unreachable!
     }
 };
 
@@ -65,12 +64,11 @@ struct DictMissing {
 
     static bool isMissing(const Dict&, std::string_view) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictMissing not specialized for this Dict");
-        mars2gribUnreachable();
+        return false;  // Unreachable!
     }
 
     static void setMissing(Dict&, std::string_view) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictMissing not specialized for this Dict");
-        mars2gribUnreachable();
     }
 };
 
@@ -79,7 +77,6 @@ struct DictGetOpt {
 
     static std::optional<T> get_opt(const Dict&, std::string_view) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictGetOpt not specialized for this Dict and type");
-        mars2gribUnreachable();
     }
 };
 
@@ -88,7 +85,6 @@ struct DictGetOrThrow {
 
     static T get_or_throw(const Dict&, std::string_view) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictGetOrThrow not specialized for this Dict and type");
-        mars2gribUnreachable();
     }
 };
 
@@ -96,7 +92,6 @@ template <class Dict, class T>
 struct DictSetOrIgnore {
     static void set_or_ignore(Dict&, std::string_view, const T&) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictSetOrIgnore not specialized for this Dict and type");
-        mars2gribUnreachable();
     }
 };
 
@@ -105,7 +100,6 @@ template <class Dict, class T>
 struct DictSetOrThrow {
     static void set_or_throw(Dict&, std::string_view, const T&) noexcept(false) {
         static_assert(dependent_false<Dict>::value, "DictSetOrThrow not specialized for this Dict and type");
-        mars2gribUnreachable();
     }
 };
 
@@ -194,9 +188,7 @@ inline T get_or_throw(const Dict& dict, std::string_view key) {
             exceptions::Mars2GribDictException("Forwarding errors while getting key `"s + std::string(key) + "` as `" +
                                                    std::string(type_name<T>()) + "` from dictionary`"s,
                                                Here()));
-        mars2gribUnreachable();
     }
-    mars2gribUnreachable();
 }
 
 // get<T>(dict,key) -> std::optional<T>
@@ -208,7 +200,6 @@ inline std::optional<T> get_opt(const Dict& dict, std::string_view key) {
     catch (...) {
         return std::nullopt;
     }
-    mars2gribUnreachable();
 }
 
 
@@ -228,22 +219,18 @@ inline void set_or_throw(Dict& dict, std::string_view key, const T& value) {
                                                                       std::string(key) + "` as `" +
                                                                       std::string(type_name<T>()) + "` to dictionary`"s,
                                                                   Here()));
-        mars2gribUnreachable();
     }
-    mars2gribUnreachable();
 }
 
 template <class T, class Dict>
 inline void set_or_ignore(Dict& dict, std::string_view key, const T& value) {
     try {
         DictSetOrIgnore<Dict, T>::set_or_ignore(dict, key, value);
-        return;
     }
     catch (...) {
         // ignore exceptions
-        mars2gribUnreachable();
     }
-    mars2gribUnreachable();
+    return;
 }
 
 

--- a/src/metkit/mars2grib/utils/enableOptions.h
+++ b/src/metkit/mars2grib/utils/enableOptions.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "metkit/mars2grib/api/Options.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::utils {
 

--- a/src/metkit/mars2grib/utils/generalUtils.h
+++ b/src/metkit/mars2grib/utils/generalUtils.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define mars2gribUnreachable() __builtin_unreachable()

--- a/src/metkit/mars2grib/utils/logUtils.h
+++ b/src/metkit/mars2grib/utils/logUtils.h
@@ -2,7 +2,6 @@
 
 #include "eckit/log/Log.h"
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 #define MARS2GRIB_LOG_CHECK(msg)                                                        \
     do {                                                                                \

--- a/src/metkit/mars2grib/utils/mars2gribExceptions.h
+++ b/src/metkit/mars2grib/utils/mars2gribExceptions.h
@@ -44,7 +44,6 @@
 // Project includes
 #include "eckit/exception/Exceptions.h"
 #include "metkit/config/LibMetkit.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 
 namespace metkit::mars2grib::utils::exceptions {

--- a/src/metkit/mars2grib/utils/type_traits_name.h
+++ b/src/metkit/mars2grib/utils/type_traits_name.h
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "metkit/codes/api/CodesTypes.h"
-#include "metkit/mars2grib/utils/generalUtils.h"
 
 namespace metkit::mars2grib::utils {
 


### PR DESCRIPTION
Remove all occurrences of `mars2gribUnreachable();`, which is an alias for `__builtin_unreachable()`. ~I found only two cases where removing the `__builtin_unreachable()` actually produces a warning and these cases can be rewritten to avoid it.~