### PR TITLE
Set date/time in StageRuntime instead of Preset

### DIFF
--- a/share/metkit/modifiers.yaml
+++ b/share/metkit/modifiers.yaml
@@ -213,7 +213,7 @@
   defaults:
     number: [0]
 - context:
-    type: ['!', pf, cm, cs, cr, cv, sv, as, fp, ed, tu, ci, me, ff, icp, sot, fcmean, fcmax, fcmin, fcstdev, svar, gwt, bf, wp]
+    type: ['!', pf, cm, cs, cr, cv, sv, as, fp, ed, tu, ci, me, ff, icp, sot, fcmean, fcmax, fcmin, fcstdev, svar, gwt, gbf, bf, wp]
     class: ['!', ti, lw, s2]
     stream: ['!', mofc, wamf, mofm, wmfm, seas, wasf, wamf, sfmm, smma, seap, swmm, ocea, mnfc, mnfh, mnfa, mnfw, mfhw, mfaw, mnfm, mfhm, mfam, mfwm, mhwm, mawm, mmsf, msmm, wams, mswm, mmsa, enda, ewda, edmm, edmo, ewmm, ewmo, elda, ewla, espd, mmaf, mmam, mmaw, mmwm, seas, efsr, wfsr, efse, wfse, ocda]
   unset: [number]

--- a/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/reference-time/referenceTimeEncoding.h
@@ -110,9 +110,9 @@ constexpr bool referenceTimeApplicable() {
 
     // Compile time conditions to apply this concept
     bool condition1 = (Variant == ReferenceTimeType::Standard || Variant == ReferenceTimeType::Reforecast) &&
-                      (Stage == StagePreset) && (Section == SecIdentificationSection);
+                      (Stage == StageRuntime) && (Section == SecIdentificationSection);
 
-    bool condition2 = (Variant == ReferenceTimeType::Reforecast) && (Stage == StagePreset) &&
+    bool condition2 = (Variant == ReferenceTimeType::Reforecast) && (Stage == StageRuntime) &&
                       (Section == SecProductDefinitionSection);
 
     // Confitions to apply concept


### PR DESCRIPTION
### Description
The mars2grib encoder currently sets date and time once in the preset stage. For climate-dt monthly means will produce increasing date/time. To efficiently reuse previously cached grib2 handles, the date/time must be set in the latest stage (runtime).

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 