### PR TITLE
Fix Healpix encoding

### DIFF
--- a/src/metkit/codes/api/CodesAPI.cc
+++ b/src/metkit/codes/api/CodesAPI.cc
@@ -407,7 +407,12 @@ std::vector<std::string> OwningCodesHandle::getStringArray(const std::string& ke
 
 std::vector<uint8_t> OwningCodesHandle::getBytes(const std::string& key) const {
     std::vector<uint8_t> ret;
-    std::size_t ksize = length(key) / 2;
+    /// Note: The returned length for bytes often is much higher than needed.
+    ///   For UIDs (i.e. "uuidOfHGrid"), the native type is BYTES, but length returns the number of characters in its
+    ///   string representation - which is twice the number of bytes. However, in contrast for fields like "bitmap" it
+    ///   directly returns the number of bytes. It has been discussed with Shahram several times without a change taking
+    ///   in.
+    std::size_t ksize = length(key);
     ret.resize(ksize);
     throwOnError(codes_get_bytes(raw(), key.c_str(), ret.data(), &ksize), Here(), "CodesHandle::getBytes(string)", key);
     ret.resize(ksize);

--- a/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
@@ -439,15 +439,15 @@ void RepresentationOp(const MarsDict_t& mars, const ParDict_t& par, const OptDic
                     const std::unique_ptr<const eckit::geo::Grid> genericGrid(eckit::geo::GridFactory::build(gridSpec));
                     const auto* grid = dynamic_cast<const eckit::geo::grid::reduced::HEALPix*>(genericGrid.get());
 
-                    const auto nside              = static_cast<long>(grid->Nside());
-                    const auto orderingConvention = grid->order() == eckit::geo::order::HEALPix::RING ? 0L : 1L;
+                    const auto nside                = static_cast<long>(grid->Nside());
+                    const auto orderingConvention   = grid->order();
                     const auto longitudeOfFirstGridPointInDegrees =
                         std::get<eckit::geo::PointLonLat>(grid->first_point()).lon();
 
                     // Encoding
                     set_or_throw<long>(out, "resolutionAndComponentFlags", 0);  // Flag table 3.3
-                    set_or_throw(out, "nside", nside);
-                    set_or_throw(out, "orderingConvention", orderingConvention);
+                    set_or_throw(out, "Nside", nside);
+                    set_or_throw<std::string>(out, "orderingConvention", orderingConvention);
                     set_or_throw(out, "longitudeOfFirstGridPointInDegrees", longitudeOfFirstGridPointInDegrees);
                 }
                 else if constexpr (Variant == RepresentationType::Orca) {

--- a/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationEncoding.h
@@ -439,8 +439,8 @@ void RepresentationOp(const MarsDict_t& mars, const ParDict_t& par, const OptDic
                     const std::unique_ptr<const eckit::geo::Grid> genericGrid(eckit::geo::GridFactory::build(gridSpec));
                     const auto* grid = dynamic_cast<const eckit::geo::grid::reduced::HEALPix*>(genericGrid.get());
 
-                    const auto nside                = static_cast<long>(grid->Nside());
-                    const auto orderingConvention   = grid->order();
+                    const auto nside              = static_cast<long>(grid->Nside());
+                    const auto orderingConvention = grid->order();
                     const auto longitudeOfFirstGridPointInDegrees =
                         std::get<eckit::geo::PointLonLat>(grid->first_point()).lon();
 

--- a/src/metkit/mars2grib/backend/concepts/representation/representationMatcher.h
+++ b/src/metkit/mars2grib/backend/concepts/representation/representationMatcher.h
@@ -36,6 +36,9 @@ std::size_t representationMatcher(const MarsDict_t& mars, const OptDict_t& opt) 
     else if (gridType == "ORCA") {
         return static_cast<std::size_t>(RepresentationType::Orca);
     }
+    else if (gridType == "healpix") {
+        return static_cast<std::size_t>(RepresentationType::Healpix);
+    }
 
     throw utils::exceptions::Mars2GribMatcherException(
         "Cannot match grid \"" + marsGrid + "\" with grid type \"" + gridType + "\"! ", Here());


### PR DESCRIPTION
### Description
Healpix case in RepresentationMatcher was missing, and in the representationEncoding Nside key is with Capital letter and orderingConvention expects a string. If you prefer we can use ordering, and keep the previous logic, which would work with the numerical value. 



### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 