### PR TITLE
introduce a hmsl

### DIFF
--- a/share/metkit/language.yaml
+++ b/share/metkit/language.yaml
@@ -655,6 +655,7 @@ _field: &_field
       - [pl, pressure levels]
       - [fl, flight levels]
       - [hl, height levels]
+      - [hmsl, height above mean sea level]
       - [pt, potential temperature]
       - [pv, potential vorticity]
       - [sfc, surf, surface] # sl ??


### PR DESCRIPTION
### Description
For some datasets that we are archiving in FDB, we are combining variables defined with typeOfFirstFixedSurface 103 and 102, that is height above ground and heigh above mean sea level. For example, flight levels relevant for aviation products are defined with 102 (hmsl). 
In order to be able to distinguish both, we need a different mars levtype, so our proposal would be to keep 103 with levtype 'hl'
and set a 'hmsl' for 102: 

'hmsl'  = {typeOfFirstFixedSurface=102; typeOfSecondFixedSurface=255;}

This would require to extend the metkit language to support it. Would that be ok? 
Any other recommendation is welcome

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
 
