### PR TITLE
fix: mars2grib guard HAVE_ECKIT_GEO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ ecbuild_add_option( FEATURE ODB
 
 ecbuild_add_option( FEATURE MARS2GRIB
                     DEFAULT ON
-                    CONDITION HAVE_GRIB
+                    CONDITION HAVE_GRIB AND HAVE_ECKIT_GEO
                     DESCRIPTION "Build the MARS2GRIB encoder" )
 
 # Python bindings for mars2grib encoder


### PR DESCRIPTION
### Description

mars2grib_libs must be guarded with HAVE_ECKIT_GEO

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
