### PR TITLE
Fix conditions for feature MARS2GRIB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ if(NOT METKIT_CONFIGS_BRANCH)
     set(METKIT_CONFIGS_BRANCH chk)
 endif()
 
+# eckit
+
+set( PERSISTENT_NAMESPACE "eckit" CACHE INTERNAL "" ) # needed for generating .b files for persistent support
+
+ecbuild_find_package( NAME eckit  VERSION  1.32 REQUIRED )
+
+
 ecbuild_add_option( FEATURE BUILD_TOOLS
                     DEFAULT ON
                     DESCRIPTION "Build the command line tools" )
@@ -64,8 +71,7 @@ ecbuild_add_option( FEATURE ODB
 
 ecbuild_add_option( FEATURE MARS2GRIB
                     DEFAULT ON
-                    # CONDITION HAVE_GRIB AND HAVE_ECKIT_GEO  ==> revert as soon as we disambiguate the eckit geo support from the one in eccodes
-                    CONDITION HAVE_GRIB
+                    CONDITION HAVE_GRIB AND eckit_HAVE_ECKIT_GEO
                     DESCRIPTION "Build the MARS2GRIB encoder" )
 
 # Python bindings for mars2grib encoder
@@ -88,11 +94,7 @@ ecbuild_add_option( FEATURE METKIT_CONFIG
 ecbuild_add_option( FEATURE FAIL_ON_CCSDS
                     DESCRIPTION "Fail on CCSDS"
                     DEFAULT OFF	 )
-# eckit
 
-set( PERSISTENT_NAMESPACE "eckit" CACHE INTERNAL "" ) # needed for generating .b files for persistent support
-
-ecbuild_find_package( NAME eckit  VERSION  1.32 REQUIRED )
 
 ############################################################################################
 # sources


### PR DESCRIPTION
The first commit sets eccodes and eckit as required packages for the feature `MARS2GRIB` then checks if target `eckit_geo` is present. If it is not present, there is an error.

The second commit sets the target `eckit_geo` as a condition for the feature `MARS2GRIB` instead.

If we want the solution of the second commit, we should squash the commits and keep the last message.