### PR TITLE
added grib2 conversion to parse-mars-request CLI tool

### DIFF
--- a/src/tools/parse-mars-request.cc
+++ b/src/tools/parse-mars-request.cc
@@ -10,6 +10,10 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
 
 #include "eckit/io/Buffer.h"
 #include "eckit/io/Offset.h"
@@ -38,18 +42,15 @@ namespace {
 class ConvertedRequests : public FlattenCallback {
 public:
 
-    ConvertedRequests(std::vector<MarsRequest>& flattenedRequests) :
-        flattenedRequests_(flattenedRequests) {}
+    ConvertedRequests(std::vector<MarsRequest>& flattenedRequests) : flattenedRequests_(flattenedRequests) {}
 
-    void operator()(const MarsRequest& req) override {
-        flattenedRequests_.push_back(converter_.convert(req).mars);
-    }
+    void operator()(const MarsRequest& req) override { flattenedRequests_.push_back(converter_.convert(req).mars); }
 
     std::vector<MarsRequest>& flattenedRequests_;
     Mars2Mars converter_;
 };
 
-}
+}  // namespace
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -59,7 +60,8 @@ public:
     ParseRequest(int argc, char** argv) : MetkitTool(argc, argv) {
         options_.push_back(new SimpleOption<bool>("json", "Format request in json, default = false"));
         options_.push_back(new SimpleOption<bool>("compact", "Compact output, default = false"));
-        options_.push_back(new SimpleOption<bool>("grib2", "Convert request to the full Grib2 metadata, default = false"));
+        options_.push_back(
+            new SimpleOption<bool>("convert-to-grib2", "Convert request to the full Grib2 metadata, default = false"));
     }
 
     virtual ~ParseRequest() {}
@@ -94,7 +96,7 @@ void ParseRequest::execute(const eckit::option::CmdArgs& args) {
 void ParseRequest::init(const CmdArgs& args) {
     args.get("json", json_);
     args.get("compact", compact_);
-    args.get("grib2", grib2_);
+    args.get("convert-to-grib2", grib2_);
     args.get("porcelain", porcelain_);
     if (porcelain_)
         compact_ = true;
@@ -161,10 +163,10 @@ void ParseRequest::process(const eckit::PathName& path) {
 
 
     std::vector<MarsRequest> v = expand.expand(p);
-    
+
     if (grib2_) {
         std::vector<MarsRequest> out;
-        
+
         for (auto& r : v) {
             MarsLanguage lang{r.verb()};
             std::vector<MarsRequest> converted;
@@ -174,7 +176,8 @@ void ParseRequest::process(const eckit::PathName& path) {
             if (converted.size() > 1) {
                 std::map<std::set<std::string>, std::vector<MarsRequest>> coherentRequests;
 
-                // split the requests into groups of requests with the same set of metadata (but potentially different values)
+                // split the requests into groups of requests with the same set of metadata (but potentially different
+                // values)
                 for (const auto& r : converted) {
                     std::set<std::string> keys;
                     for (const auto& p : r.parameters()) {
@@ -195,8 +198,8 @@ void ParseRequest::process(const eckit::PathName& path) {
                     for (size_t i = 1; i < reqs.size(); ++i) {
                         merged.merge(reqs[i]);
                     }
-                    if (merged.count() ==
-                        reqs.size()) {  // the set of fields forms a full hypercube - return corresponding merged request
+                    if (merged.count() == reqs.size()) {  // the set of fields forms a full hypercube - return
+                                                          // corresponding merged request
                         converted.push_back(std::move(merged));
                         continue;
                     }

--- a/src/tools/parse-mars-request.cc
+++ b/src/tools/parse-mars-request.cc
@@ -17,16 +17,39 @@
 #include "eckit/option/CmdArgs.h"
 #include "eckit/option/SimpleOption.h"
 
+#include "metkit/hypercube/HyperCube.h"
 #include "metkit/mars/MarsExpansion.h"
+#include "metkit/mars/MarsLanguage.h"
 #include "metkit/mars/MarsParser.h"
 #include "metkit/mars/MarsRequest.h"
 #include "metkit/tool/MetkitTool.h"
 
+#include "metkit/mars2mars/api/Mars2Mars.h"
+#include "metkit/mars2mars/utils/dictionary_traits/dictaccess_mars_request.h"
+#include "metkit/mars2mars/utils/dictionary_traits/dictionary_access_traits.h"
 
 using namespace metkit;
 using namespace metkit::mars;
+using namespace metkit::mars2mars;
 using namespace eckit;
 using namespace eckit::option;
+
+namespace {
+class ConvertedRequests : public FlattenCallback {
+public:
+
+    ConvertedRequests(std::vector<MarsRequest>& flattenedRequests) :
+        flattenedRequests_(flattenedRequests) {}
+
+    void operator()(const MarsRequest& req) override {
+        flattenedRequests_.push_back(converter_.convert(req).mars);
+    }
+
+    std::vector<MarsRequest>& flattenedRequests_;
+    Mars2Mars converter_;
+};
+
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -36,6 +59,7 @@ public:
     ParseRequest(int argc, char** argv) : MetkitTool(argc, argv) {
         options_.push_back(new SimpleOption<bool>("json", "Format request in json, default = false"));
         options_.push_back(new SimpleOption<bool>("compact", "Compact output, default = false"));
+        options_.push_back(new SimpleOption<bool>("grib2", "Convert request to the full Grib2 metadata, default = false"));
     }
 
     virtual ~ParseRequest() {}
@@ -56,6 +80,7 @@ private:  // members
 
     bool json_    = false;
     bool compact_ = false;
+    bool grib2_   = false;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -69,6 +94,7 @@ void ParseRequest::execute(const eckit::option::CmdArgs& args) {
 void ParseRequest::init(const CmdArgs& args) {
     args.get("json", json_);
     args.get("compact", compact_);
+    args.get("grib2", grib2_);
     args.get("porcelain", porcelain_);
     if (porcelain_)
         compact_ = true;
@@ -82,6 +108,7 @@ void ParseRequest::usage(const std::string& tool) const {
                 << std::endl
                 << tool << " --json mars1.req mars2.req" << std::endl
                 << tool << " --porcelain folderOfRequests" << std::endl
+                << tool << " --grib2 mars1.req mars2.req" << std::endl
                 << std::endl;
 }
 
@@ -134,6 +161,60 @@ void ParseRequest::process(const eckit::PathName& path) {
 
 
     std::vector<MarsRequest> v = expand.expand(p);
+    
+    if (grib2_) {
+        std::vector<MarsRequest> out;
+        
+        for (auto& r : v) {
+            MarsLanguage lang{r.verb()};
+            std::vector<MarsRequest> converted;
+            ConvertedRequests cb(converted);
+            lang.flatten(r, cb);
+
+            if (converted.size() > 1) {
+                std::map<std::set<std::string>, std::vector<MarsRequest>> coherentRequests;
+
+                // split the requests into groups of requests with the same set of metadata (but potentially different values)
+                for (const auto& r : converted) {
+                    std::set<std::string> keys;
+                    for (const auto& p : r.parameters()) {
+                        keys.insert(p.name());
+                    }
+                    coherentRequests[keys].push_back(r);
+                }
+                converted.clear();
+
+                // compact each group of requests into a single request (if possible)
+                for (const auto& [keys, reqs] : coherentRequests) {
+                    if (reqs.size() == 1) {  // it is a single field - return its request as is
+                        converted.push_back(reqs.front());
+                        continue;
+                    }
+
+                    MarsRequest merged{reqs.front()};
+                    for (size_t i = 1; i < reqs.size(); ++i) {
+                        merged.merge(reqs[i]);
+                    }
+                    if (merged.count() ==
+                        reqs.size()) {  // the set of fields forms a full hypercube - return corresponding merged request
+                        converted.push_back(std::move(merged));
+                        continue;
+                    }
+
+                    // sparse hypercube - we have to compute a set of compact requests describing the input fields
+                    metkit::hypercube::HyperCube h{merged};
+                    for (const auto& r : reqs) {
+                        h.clear(r);
+                    }
+                    for (const auto& r : h.requests()) {
+                        converted.push_back(r);
+                    }
+                }
+            }
+            out.insert(out.end(), converted.begin(), converted.end());
+        }
+        std::swap(v, out);
+    }
 
     for (std::vector<MarsRequest>::const_iterator j = v.begin(); j != v.end(); ++j) {
         if (json_) {

--- a/tests/mars2grib/utils/dictionary_traits/mars2grib-localConfigurationTraits-tests.cc
+++ b/tests/mars2grib/utils/dictionary_traits/mars2grib-localConfigurationTraits-tests.cc
@@ -336,13 +336,15 @@ CASE("Test generic has missing") {
 
 CASE("Test generic typed has valid") {
 
-#define TEST_TYPED_HAS_VALID(TYPE, TYPENAME_STRING, KEY)                                         \
-    {SECTION("has<" TYPENAME_STRING "> valid"){using metkit::mars2grib::utils::dict_traits::has; \
-    EXPECT_NO_THROW({                                                                            \
-        bool actual_has = has<TYPE>(cfg, (KEY));                                                 \
-        EXPECT(actual_has);                                                                      \
-    });                                                                                          \
-    }                                                                                            \
+#define TEST_TYPED_HAS_VALID(TYPE, TYPENAME_STRING, KEY)      \
+    {                                                         \
+        SECTION("has<" TYPENAME_STRING "> valid") {           \
+            using metkit::mars2grib::utils::dict_traits::has; \
+            EXPECT_NO_THROW({                                 \
+                bool actual_has = has<TYPE>(cfg, (KEY));      \
+                EXPECT(actual_has);                           \
+            });                                               \
+        }                                                     \
     }
 
     // Prepare a custom dictionary to test long


### PR DESCRIPTION
### Description

add --grib2 flag to parse-mars-request, to trigger mars request conversion to the mtg2 version

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
